### PR TITLE
Big changes. Added Gaiden support. No loading screen between songs.

### DIFF
--- a/DaniDojo/Assets/CommonAssets.cs
+++ b/DaniDojo/Assets/CommonAssets.cs
@@ -41,7 +41,7 @@ namespace DaniDojo.Assets
             var songTitleInfo = wordDataMgr.GetWordListInfo("song_" + song.SongId);
             string songTitle;
 
-            if (songTitleInfo != null)
+            if (songTitleInfo != null && songTitleInfo.Text != "")
             {
                 songTitle = songTitleInfo.Text;
             }
@@ -154,52 +154,209 @@ namespace DaniDojo.Assets
             return AssetUtility.CreateImageChild(parent, "SongLevel", position, Path.Combine(AssetFilePath, "DifficultyAssets", file));
         }
 
+        static public GameObject CreateCourseTitleBar(GameObject parent, Vector2 position, DaniCourse course)
+        {
+            if (course.CourseLevel != DaniCourseLevel.gaiden &&
+                course.CourseLevel != DaniCourseLevel.sousaku)
+            {
+                return null;
+            }
+
+            string bgImage = string.Empty;
+            if (course.CourseLevel == DaniCourseLevel.gaiden)
+            {
+                bgImage = "GaidenTitleBg.png";
+            }
+            else if (course.CourseLevel == DaniCourseLevel.sousaku)
+            {
+                bgImage = "SousakuTitleBg.png";
+            }
+
+            var titleBarObject = AssetUtility.CreateImageChild(parent, "CourseTitleBar", position, Path.Combine("Course", "CourseSelect", bgImage));
+
+            var wordDataMgr = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.WordDataMgr;
+            FontTMPManager fontTMPMgr = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.FontTMPMgr;
+
+            // Using Hoshikuzu struck as a base, assuming it will have accurate font data
+            // It might not have accurate font data for detail
+            var titleFontType = wordDataMgr.GetWordListInfo("song_struck").FontType;
+            var titleFont = fontTMPMgr.GetDefaultFontAsset(titleFontType);
+            var titleFontMaterial = fontTMPMgr.GetDefaultFontMaterial(titleFontType, DataConst.DefaultFontMaterialType.KanbanSelect);
+
+            string courseTitle = course.Title;
+            if ((Plugin.Instance.ConfigSongTitleLanguage.Value == "Jp" || course.EngTitle == "") && course.JpTitle != "")
+            {
+                courseTitle = course.JpTitle;
+            }
+            else if ((Plugin.Instance.ConfigSongTitleLanguage.Value == "Eng" || course.JpTitle == "") && course.EngTitle != "")
+            {
+                courseTitle = course.EngTitle;
+            }
+
+            var titleText = AssetUtility.CreateTextChild(titleBarObject, "Title", new Rect(72, 6, 950, 70), courseTitle);
+            AssetUtility.SetTextFontAndMaterial(titleText, titleFont, titleFontMaterial);
+            AssetUtility.SetTextAlignment(titleText, HorizontalAlignmentOptions.Left);
+            AssetUtility.SetTextFontSize(titleText, 41);
+
+            return titleBarObject;
+        }
+
         static public GameObject CreateDaniCourse(GameObject parent, Vector2 position, DaniCourse course)
         {
             string bgImageFile = course.Background switch
             {
-                CourseBackground.Tan => bgImageFile = "TanBg.png",
-                CourseBackground.Wood => bgImageFile = "WoodBg.png",
-                CourseBackground.Blue => bgImageFile = "BlueBg.png",
-                CourseBackground.Red => bgImageFile = "RedBg.png",
-                CourseBackground.Silver => bgImageFile = "SilverBg.png",
-                CourseBackground.Gold => bgImageFile = "GoldBg.png",
-                _ => bgImageFile = "TanBg.png",
+                CourseBackground.Tan => "Tan.png",
+                CourseBackground.Wood => "Wood.png",
+                CourseBackground.Blue => "Blue.png",
+                CourseBackground.Red => "Red.png",
+                CourseBackground.Silver => "Silver.png",
+                CourseBackground.Gold => "Gold.png",
+                CourseBackground.Gaiden => "Gaiden.png",
+                CourseBackground.Sousaku => "Sousaku.png",
+                _ => "Sousaku.png",
             };
 
-            var courseId = course.Id;
-            if (int.TryParse(courseId, out int _))
+            string topJpText = string.Empty;
+            string botJpText = string.Empty;
+            string topEngText = string.Empty;
+            string botEngText = string.Empty;
+
+            switch (course.CourseLevel)
             {
-                courseId = course.Title;
+                case DaniCourseLevel.kyuuFirst:
+                case DaniCourseLevel.dan1:
+                    topJpText = "Starting.png";
+                    topEngText = "First.png";
+                    break;
+                case DaniCourseLevel.kyuu10:
+                case DaniCourseLevel.dan10:
+                    topJpText = "10th.png";
+                    topEngText = "Tenth.png";
+                    break;
+                case DaniCourseLevel.kyuu9:
+                case DaniCourseLevel.dan9:
+                    topJpText = "9th.png";
+                    topEngText = "Ninth.png";
+                    break;
+                case DaniCourseLevel.kyuu8:
+                case DaniCourseLevel.dan8:
+                    topJpText = "8th.png";
+                    topEngText = "Eighth.png";
+                    break;
+                case DaniCourseLevel.kyuu7:
+                case DaniCourseLevel.dan7:
+                    topJpText = "7th.png";
+                    topEngText = "Seventh.png";
+                    break;
+                case DaniCourseLevel.kyuu6:
+                case DaniCourseLevel.dan6:
+                    topJpText = "6th.png";
+                    topEngText = "Sixth.png";
+                    break;
+                case DaniCourseLevel.kyuu5:
+                case DaniCourseLevel.dan5:
+                    topJpText = "5th.png";
+                    topEngText = "Fifth.png";
+                    break;
+                case DaniCourseLevel.kyuu4:
+                case DaniCourseLevel.dan4:
+                    topJpText = "4th.png";
+                    topEngText = "Fourth.png";
+                    break;
+                case DaniCourseLevel.kyuu3:
+                case DaniCourseLevel.dan3:
+                    topJpText = "3rd.png";
+                    topEngText = "Third.png";
+                    break;
+                case DaniCourseLevel.kyuu2:
+                case DaniCourseLevel.dan2:
+                    topJpText = "2nd.png";
+                    topEngText = "Second.png";
+                    break;
+                case DaniCourseLevel.kyuu1:
+                    topJpText = "1st.png";
+                    topEngText = "First.png";
+                    break;
+                case DaniCourseLevel.kuroto:
+                    topJpText = "kuro.png";
+                    topEngText = "Kuroto.png";
+                    break;
+                case DaniCourseLevel.meijin:
+                    topJpText = "mei.png";
+                    topEngText = "Meijin.png";
+                    break;
+                case DaniCourseLevel.chojin:
+                    topJpText = "cho.png";
+                    topEngText = "Chojin.png";
+                    break;
+                case DaniCourseLevel.tatsujin:
+                    topJpText = "tatsu.png";
+                    topEngText = "Tatsujin.png";
+                    break;
+                case DaniCourseLevel.gaiden:
+                    topJpText = "gai.png";
+                    botJpText = "den.png";
+                    topEngText = "Gaiden.png";
+                    break;
+                default:
+                    topJpText = "sou.png";
+                    botJpText = "saku.png";
+                    topEngText = "Sousaku.png";
+                    break;
             }
 
-            string textImageBg = courseId switch
+            switch (course.CourseLevel)
             {
-                "5kyuu" or "五級 5th Kyu" => textImageBg = "kyuu5.png",
-                "4kyuu" or "四級 4th Kyu" => textImageBg = "kyuu4.png",
-                "3kyuu" or "三級 3rd Kyu" => textImageBg = "kyuu3.png",
-                "2kyuu" or "二級 2nd Kyu" => textImageBg = "kyuu2.png",
-                "1kyuu" or "一級 1st Kyu" => textImageBg = "kyuu1.png",
-                "1dan" or "初段 1st Dan" => textImageBg = "dan1.png",
-                "2dan" or "二段 2nd Dan" => textImageBg = "dan2.png",
-                "3dan" or "三段 3rd Dan" => textImageBg = "dan3.png",
-                "4dan" or "四段 4th Dan" => textImageBg = "dan4.png",
-                "5dan" or "五段 5th Dan" => textImageBg = "dan5.png",
-                "6dan" or "六段 6th Dan" => textImageBg = "dan6.png",
-                "7dan" or "七段 7th Dan" => textImageBg = "dan7.png",
-                "8dan" or "八段 8th Dan" => textImageBg = "dan8.png",
-                "9dan" or "九段 9th Dan" => textImageBg = "dan9.png",
-                "10dan" or "十段 10th Dan" => textImageBg = "dan10.png",
-                "11dan" or "玄人 Kuroto" => textImageBg = "kuroto.png",
-                "12dan" or "名人 Meijin" => textImageBg = "meijin.png",
-                "13dan" or "超人 Chojin" => textImageBg = "chojin.png",
-                "14dan" or "達人 Tatsujin" => textImageBg = "tatsujin.png",
-                _ => textImageBg = "gaiden.png",
-            };
+                case DaniCourseLevel.kyuuFirst:
+                case DaniCourseLevel.kyuu10:
+                case DaniCourseLevel.kyuu9:
+                case DaniCourseLevel.kyuu8:
+                case DaniCourseLevel.kyuu7:
+                case DaniCourseLevel.kyuu6:
+                case DaniCourseLevel.kyuu5:
+                case DaniCourseLevel.kyuu4:
+                case DaniCourseLevel.kyuu3:
+                case DaniCourseLevel.kyuu2:
+                case DaniCourseLevel.kyuu1:
+                    botJpText = "kyuu.png";
+                    botEngText = "Kyu.png";
+                    break;
+                case DaniCourseLevel.dan1:
+                case DaniCourseLevel.dan2:
+                case DaniCourseLevel.dan3:
+                case DaniCourseLevel.dan4:
+                case DaniCourseLevel.dan5:
+                case DaniCourseLevel.dan6:
+                case DaniCourseLevel.dan7:
+                case DaniCourseLevel.dan8:
+                case DaniCourseLevel.dan9:
+                case DaniCourseLevel.dan10:
+                    botJpText = "dan.png";
+                    botEngText = "Dan.png";
+                    break;
+                case DaniCourseLevel.kuroto:
+                case DaniCourseLevel.meijin:
+                case DaniCourseLevel.chojin:
+                case DaniCourseLevel.tatsujin:
+                    botJpText = "jin.png";
+                    break;
+            }
+
 
             var daniCourseParent = AssetUtility.CreateEmptyObject(parent, "DaniCourse", position);
-            AssetUtility.CreateImageChild(daniCourseParent, "Background", new Vector2(0, 0), Path.Combine(AssetFilePath, "Course", "DaniCourseIcons", bgImageFile));
-            AssetUtility.CreateImageChild(daniCourseParent, "Text", new Vector2(52, 124), Path.Combine(AssetFilePath, "Course", "DaniCourseIcons", textImageBg));
+            AssetUtility.CreateImageChild(daniCourseParent, "Background", new Vector2(0, -1), Path.Combine("Course", "Main", "Bg", bgImageFile));
+            var textParent = AssetUtility.GetOrCreateEmptyChild(daniCourseParent, "Text", new Vector2(52, 124));
+            AssetUtility.CreateImageChild(textParent, "TopJpText", new Vector2(12, 225), Path.Combine("Course", "Main", "JpText", topJpText));
+            AssetUtility.CreateImageChild(textParent, "BotJpText", new Vector2(12, 93), Path.Combine("Course", "Main", "JpText", botJpText));
+            if (botEngText == string.Empty)
+            {
+                AssetUtility.CreateImageChild(textParent, "EngText", new Vector2(0, 16), Path.Combine("Course", "Main", "EngText", topEngText));
+            }
+            else
+            {
+                AssetUtility.CreateImageChild(textParent, "TopEngText", new Vector2(0, 30), Path.Combine("Course", "Main", "EngText", topEngText));
+                AssetUtility.CreateImageChild(textParent, "BotEngText", new Vector2(0, 00), Path.Combine("Course", "Main", "EngText", botEngText));
+            }
 
             return daniCourseParent;
         }

--- a/DaniDojo/Assets/ResultsAssets.cs
+++ b/DaniDojo/Assets/ResultsAssets.cs
@@ -14,25 +14,9 @@ namespace DaniDojo.Assets
 {
     internal class ResultsAssets
     {
-        // I don't want these to be here
-        static Color32 GoldReqTextBorderColor = new Color32(221, 89, 56, 255);
-        static Color32 GoldReqTextFillColor = new Color32(255, 93, 127, 255);
-        static Color32 GoldReqTextTransparentColor = new Color32(255, 244, 45, 255);
-
-        static Color32 NormalTextBorderColor = new Color32(177, 177, 177, 255);
-        static Color32 NormalTextFillColor = new Color32(255, 255, 255, 255);
-        static Color32 NormalTextTransparentColor = new Color32(0, 0, 0, 0);
-
-        static Color32 ZeroTextBorderColor = new Color32(177, 177, 177, 255);
-        static Color32 ZeroTextFillColor = new Color32(0, 0, 0, 0);
-        static Color32 ZeroTextTransparentColor = new Color32(0, 0, 0, 0);
-
-
-        static string AssetFilePath => Plugin.Instance.ConfigDaniDojoAssetLocation.Value;
-
         static public GameObject CreateBg(GameObject parent)
         {
-            return AssetUtility.CreateImageChild(parent, "DaniResultBg", new Vector2(0, 0), Path.Combine(AssetFilePath, "Results", "Background.png"));
+            return AssetUtility.CreateImageChild(parent, "DaniResultBg", new Vector2(0, 0), Path.Combine("Results", "Background.png"));
         }
 
         static public GameObject CreateCourseIcon(GameObject parent, DaniCourse course)
@@ -41,9 +25,15 @@ namespace DaniDojo.Assets
             return CommonAssets.CreateDaniCourse(parent, new Vector2(77, 472), course);
         }
 
+        static public GameObject CreateCourseTitle(GameObject parent, DaniCourse course)
+        {
+            return CommonAssets.CreateCourseTitleBar(parent, new Vector2(347, 954), course);
+        }
+
+
         static public GameObject CreateSongPanel(GameObject parent)
         {
-            var songBg = AssetUtility.CreateImageChild(parent, "SongMainBg", new Vector2(352, 69), Path.Combine(AssetFilePath, "Results", "SongsWoodBackground.png"));
+            var songBg = AssetUtility.CreateImageChild(parent, "SongMainBg", new Vector2(352, 69), Path.Combine("Results", "SongsWoodBackground.png"));
             //CreateEachSongBg(songBg);
             return songBg;
         }
@@ -54,27 +44,27 @@ namespace DaniDojo.Assets
             {
                 int x = 28;
                 int y = 607 - (i * 276);
-                var songBg = AssetUtility.CreateImageChild(parent, "SongBg", new Vector2(x, y), Path.Combine(AssetFilePath, "Results", "SongBg.png"));
-                var songPanel = AssetUtility.CreateImageChild(songBg, "SongPanel" + i, new Vector2(38, 119), Path.Combine(AssetFilePath, "Results", "SongPanel.png"));
+                var songBg = AssetUtility.CreateImageChild(parent, "SongBg", new Vector2(x, y), Path.Combine("Results", "SongBg.png"));
+                var songPanel = AssetUtility.CreateImageChild(songBg, "SongPanel" + i, new Vector2(38, 119), Path.Combine("Results", "SongPanel.png"));
 
-                AssetUtility.CreateImageChild(songPanel, "SongIndicator", new Vector2(10, 10), Path.Combine(AssetFilePath, "Results", "SongIndicator" + (i + 1) + ".png"));
+                AssetUtility.CreateImageChild(songPanel, "SongIndicator", new Vector2(10, 10), Path.Combine("Results", "SongIndicator" + (i + 1) + ".png"));
 
                 CommonAssets.CreateSongCourseChild(songPanel, new Vector2(112, 42), course.Songs[i]);
                 CommonAssets.CreateSongLevelChild(songPanel, new Vector2(121, 15), course.Songs[i]);
 
-                var songTitle = CommonAssets.CreateSongTitleChild(songPanel, new Vector2(220, 28), course.Songs[i], Math.Max(play.SongReached, save.SongReached) <= i && course.Songs[i].IsHidden);
-                var songDetail = CommonAssets.CreateSongDetailChild(songPanel, new Vector2(220, 70), course.Songs[i], Math.Max(play.SongReached, save.SongReached) <= i && course.Songs[i].IsHidden);
+                var songTitle = CommonAssets.CreateSongTitleChild(songPanel, new Vector2(218, 30), course.Songs[i], Math.Max(play.SongReached, save.SongReached) <= i && course.Songs[i].IsHidden);
+                var songDetail = CommonAssets.CreateSongDetailChild(songPanel, new Vector2(218, 70), course.Songs[i], Math.Max(play.SongReached, save.SongReached) <= i && course.Songs[i].IsHidden);
 
                 int valuesX = 136;
                 int valuesY = 37;
                 int valuesInterval = 317;
-                var songGoodsPanel = AssetUtility.CreateImageChild(songBg, "SongGoodsPanel", new Vector2(valuesX, valuesY), Path.Combine(AssetFilePath, "Results", "SongGoodsBg.png"));
+                var songGoodsPanel = AssetUtility.CreateImageChild(songBg, "SongGoodsPanel", new Vector2(valuesX, valuesY), Path.Combine("Results", "SongGoodsBg.png"));
                 valuesX += valuesInterval;
-                var songOksPanel = AssetUtility.CreateImageChild(songBg, "SongOksPanel", new Vector2(valuesX, valuesY), Path.Combine(AssetFilePath, "Results", "SongOksBg.png"));
+                var songOksPanel = AssetUtility.CreateImageChild(songBg, "SongOksPanel", new Vector2(valuesX, valuesY), Path.Combine("Results", "SongOksBg.png"));
                 valuesX += valuesInterval;
-                var songBadsPanel = AssetUtility.CreateImageChild(songBg, "SongBadsPanel", new Vector2(valuesX, valuesY), Path.Combine(AssetFilePath, "Results", "SongBadsBg.png"));
+                var songBadsPanel = AssetUtility.CreateImageChild(songBg, "SongBadsPanel", new Vector2(valuesX, valuesY), Path.Combine("Results", "SongBadsBg.png"));
                 valuesX += valuesInterval;
-                var songDrumrollsPanel = AssetUtility.CreateImageChild(songBg, "SongDrumrollPanel", new Vector2(valuesX, valuesY), Path.Combine(AssetFilePath, "Results", "SongDrumrollBg.png"));
+                var songDrumrollsPanel = AssetUtility.CreateImageChild(songBg, "SongDrumrollPanel", new Vector2(valuesX, valuesY), Path.Combine("Results", "SongDrumrollBg.png"));
 
                 var goods = play.SongPlayData[i].Goods.ToString();
                 var oks = play.SongPlayData[i].Oks.ToString();
@@ -107,13 +97,13 @@ namespace DaniDojo.Assets
 
         static public GameObject CreatePlayRecordBg(GameObject parent)
         {
-            var playRecordBg = AssetUtility.CreateImageChild(parent, "PlayRecord", new Vector2(337 + 1920, 44), Path.Combine(AssetFilePath, "Results", "PlayResultsBackground.png"));
+            var playRecordBg = AssetUtility.CreateImageChild(parent, "PlayRecord", new Vector2(337 + 1920, 44), Path.Combine("Results", "PlayResultsBackground.png"));
             return playRecordBg;
         }
 
         static public GameObject CreatePlayRecordScoreBg(GameObject parent, PlayData play)
         {
-            var scoreBg = AssetUtility.CreateImageChild(parent, "ScoreBg", new Vector2(128, 752), Path.Combine(AssetFilePath, "Results", "PlayScoreBg.png"));
+            var scoreBg = AssetUtility.CreateImageChild(parent, "ScoreBg", new Vector2(128, 752), Path.Combine("Results", "PlayScoreBg.png"));
 
             var textObject = AssetUtility.CreateTextChild(scoreBg, "ScoreBgText", new Rect(74, 102, 300, 40), "Score");
             AssetUtility.SetTextAlignment(textObject, HorizontalAlignmentOptions.Center);
@@ -147,7 +137,7 @@ namespace DaniDojo.Assets
 
         static public GameObject CreatePlayRecordGoodOkBad(GameObject parent, PlayData play)
         {
-            var playRecordBg = AssetUtility.CreateImageChild(parent, "PlayRecordBg1", new Vector2(571, 696), Path.Combine(AssetFilePath, "Results", "PlayRecord1.png"));
+            var playRecordBg = AssetUtility.CreateImageChild(parent, "PlayRecordBg1", new Vector2(571, 696), Path.Combine("Results", "PlayRecord1.png"));
 
             var goods = play.SongPlayData.Sum((x) => x.Goods).ToString();
             var oks = play.SongPlayData.Sum((x) => x.Oks).ToString();
@@ -175,7 +165,7 @@ namespace DaniDojo.Assets
 
         static public GameObject CreatePlayRecordDrumrollComboTotalHits(GameObject parent, PlayData play)
         {
-            var playRecordBg = AssetUtility.CreateImageChild(parent, "PlayRecordBg2", new Vector2(955, 696), Path.Combine(AssetFilePath, "Results", "PlayRecord2.png"));
+            var playRecordBg = AssetUtility.CreateImageChild(parent, "PlayRecordBg2", new Vector2(955, 696), Path.Combine("Results", "PlayRecord2.png"));
 
             var drumroll = play.SongPlayData.Sum((x) => x.Drumroll).ToString();
             var combo = play.MaxCombo.ToString();
@@ -228,26 +218,26 @@ namespace DaniDojo.Assets
 
             if (isFailed)
             {
-                AssetUtility.CreateImageChild(danResultParent, "FailShadow1", new Vector2(3, 55), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailShadow1.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailShadow2", new Vector2(109, -14), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailShadow2.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailShadow3", new Vector2(232, 21), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailShadow3.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailShadow1", new Vector2(3, 55), Path.Combine("Results", "DaniResult", "ResultFailShadow1.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailShadow2", new Vector2(109, -14), Path.Combine("Results", "DaniResult", "ResultFailShadow2.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailShadow3", new Vector2(232, 21), Path.Combine("Results", "DaniResult", "ResultFailShadow3.png"));
 
-                AssetUtility.CreateImageChild(danResultParent, "FailBg1", new Vector2(15, 78), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailBackground1.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailBg2", new Vector2(123, 9), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailBackground2.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailBg3", new Vector2(245, 43), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailBackground3.png"));
-                                              
-                AssetUtility.CreateImageChild(danResultParent, "FailOutline1", new Vector2(19, 76), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailOutline1.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailOutline2", new Vector2(127, 7), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailOutline2.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailOutline3", new Vector2(248, 41), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailOutline3.png"));
-                                              
-                AssetUtility.CreateImageChild(danResultParent, "FailText1", new Vector2(32, 93), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailText1.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailText2", new Vector2(140, 26), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailText2.png"));
-                AssetUtility.CreateImageChild(danResultParent, "FailText3", new Vector2(261, 60), Path.Combine(AssetFilePath, "Results", "DaniResult", "ResultFailText3.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailBg1", new Vector2(15, 78), Path.Combine("Results", "DaniResult", "ResultFailBackground1.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailBg2", new Vector2(123, 9), Path.Combine("Results", "DaniResult", "ResultFailBackground2.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailBg3", new Vector2(245, 43), Path.Combine("Results", "DaniResult", "ResultFailBackground3.png"));
+
+                AssetUtility.CreateImageChild(danResultParent, "FailOutline1", new Vector2(19, 76), Path.Combine("Results", "DaniResult", "ResultFailOutline1.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailOutline2", new Vector2(127, 7), Path.Combine("Results", "DaniResult", "ResultFailOutline2.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailOutline3", new Vector2(248, 41), Path.Combine("Results", "DaniResult", "ResultFailOutline3.png"));
+
+                AssetUtility.CreateImageChild(danResultParent, "FailText1", new Vector2(32, 93), Path.Combine("Results", "DaniResult", "ResultFailText1.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailText2", new Vector2(140, 26), Path.Combine("Results", "DaniResult", "ResultFailText2.png"));
+                AssetUtility.CreateImageChild(danResultParent, "FailText3", new Vector2(261, 60), Path.Combine("Results", "DaniResult", "ResultFailText3.png"));
             }
             else
             {
-                AssetUtility.CreateImageChild(danResultParent, "ComboBg", new Vector2(0, 0), Path.Combine(AssetFilePath, "Results", "DaniResult", comboAsset));
-                AssetUtility.CreateImageChild(danResultParent, "Rank", new Vector2(21, 39), Path.Combine(AssetFilePath, "Results", "DaniResult", resultAsset));
+                AssetUtility.CreateImageChild(danResultParent, "ComboBg", new Vector2(0, 0), Path.Combine("Results", "DaniResult", comboAsset));
+                AssetUtility.CreateImageChild(danResultParent, "Rank", new Vector2(21, 39), Path.Combine("Results", "DaniResult", resultAsset));
             }
             return danResultParent;
         }
@@ -268,7 +258,7 @@ namespace DaniDojo.Assets
         {
             var borderPanel = AssetUtility.CreateEmptyObject(parent, name, position);
 
-            var borderPanelBg = AssetUtility.CreateImageChild(borderPanel, "BorderBg", new Vector2(0, 0), Path.Combine(AssetFilePath, "Results", "BorderResultsPanel.png"));
+            var borderPanelBg = AssetUtility.CreateImageChild(borderPanel, "BorderBg", new Vector2(0, 0), Path.Combine("Results", "BorderResultsPanel.png"));
 
             var fontManager = GameObject.Find("FontTMPManager").GetComponent<FontTMPManager>();
             TMP_FontAsset reqTypefont = fontManager.GetDefaultFontAsset(DataConst.FontType.EFIGS);
@@ -315,11 +305,11 @@ namespace DaniDojo.Assets
 
             if (border.BorderType == BorderType.SoulGauge)
             {
-                AssetUtility.CreateImageChild(borderPanel, "SongNumIndicator", new Vector2(28, 30), Path.Combine(AssetFilePath, "Enso", "CurSongIndicatorTotal.png"));
+                AssetUtility.CreateImageChild(borderPanel, "SongNumIndicator", new Vector2(28, 30), Path.Combine("Enso", "CurSongIndicatorTotal.png"));
 
                 var soulGauge = AssetUtility.CreateEmptyObject(borderPanel, "SoulGauge", new Vector2(50, 20));
-                var soulGaugeBg = AssetUtility.CreateImageChild(soulGauge, "SoulGaugeBg", new Vector2(75, 8), Path.Combine(AssetFilePath, "SoulGauge", "ResultsSoulGaugeBg.png"));
-                var soulGaugeSeparators = AssetUtility.CreateImageChild(soulGauge, "SoulGaugeSeparators", new Vector2(131, 21), Path.Combine(AssetFilePath, "SoulGauge", "SoulGaugeBarSeparators.png"));
+                var soulGaugeBg = AssetUtility.CreateImageChild(soulGauge, "SoulGaugeBg", new Vector2(75, 8), Path.Combine("SoulGauge", "ResultsSoulGaugeBg.png"));
+                var soulGaugeSeparators = AssetUtility.CreateImageChild(soulGauge, "SoulGaugeSeparators", new Vector2(131, 21), Path.Combine("SoulGauge", "SoulGaugeBarSeparators.png"));
             }
             else if (border.IsTotal)
             {
@@ -344,7 +334,7 @@ namespace DaniDojo.Assets
             }
 
             // Create SongNumIndicator (Always Total for this panel)
-            AssetUtility.CreateImageChild(parent, "SongNumIndicator", new Vector2(28, 30), Path.Combine(AssetFilePath, "Enso", "CurSongIndicatorTotal.png"));
+            AssetUtility.CreateImageChild(parent, "SongNumIndicator", new Vector2(28, 30), Path.Combine("Enso", "CurSongIndicatorTotal.png"));
 
 
             // Create the requirement value string
@@ -370,14 +360,14 @@ namespace DaniDojo.Assets
 
 
             // Create the requirement bars
-            var barData = DaniPlayManager.GetBorderBarData(border, play);
+            var barData = DaniPlayManager.GetBorderBarData(border, play, remainingNotes: 0);
             var bar = AssetUtility.CreateEmptyObject(parent, "RequirementBar", new Vector2(13, -4));
 
             var curReqBarImagePath = Path.Combine("Enso", "Bars", "RequirementBarTotal.png");
             var curReqBarBorderImagePath = Path.Combine("Enso", "Bars", "RequirementBarBorderTotal.png");
 
             Vector2 barPositions = new Vector2(389, 20);
-            AssetUtility.CreateImageChild(bar, "CurReqBar", barPositions, Path.Combine(AssetFilePath, curReqBarImagePath));
+            AssetUtility.CreateImageChild(bar, "CurReqBar", barPositions, Path.Combine(curReqBarImagePath));
 
             Rect fillBarRect = new Rect(396, 36, 966, 80);
             Rect emptyBarRect = new Rect(396 + 966, 36, 966, 80);
@@ -388,7 +378,7 @@ namespace DaniDojo.Assets
             var fillBar = AssetUtility.CreateImageChild(bar, "CurReqBarFill", fillBarRect, barData.Color);
             var colorLerp = fillBar.AddComponent<ColorLerp>();
             var emptyBar = AssetUtility.CreateImageChild(bar, "CurReqBarEmpty", emptyBarRect, BorderBarColors.BorderBarColor[BorderBarState.Grey]);
-            AssetUtility.CreateImageChild(bar, "CurReqBarBorder", barPositions, Path.Combine(AssetFilePath, curReqBarBorderImagePath));
+            AssetUtility.CreateImageChild(bar, "CurReqBarBorder", barPositions, Path.Combine(curReqBarBorderImagePath));
 
             var fillBarImage = AssetUtility.GetOrAddImageComponent(fillBar);
 
@@ -414,7 +404,7 @@ namespace DaniDojo.Assets
             var barState = DigitAssets.GetRequirementBarState(barData, border);
             DigitAssets.CreateRequirementBarNumber(bar, new Vector2(403, 44), barData.PlayValue, RequirementBarType.Large, barState);
 
-           
+
 
 
 
@@ -433,7 +423,7 @@ namespace DaniDojo.Assets
             {
                 // Create SongNumIndicator
                 var songPanel = AssetUtility.CreateEmptyObject(parent, "Song" + (i + 1), new Vector2(0 + (i * 465), 0));
-                AssetUtility.CreateImageChild(songPanel, "SongNumIndicator", new Vector2(28, 30), Path.Combine(AssetFilePath, "Enso", "CurSongIndicator" + (i + 1) + ".png"));
+                AssetUtility.CreateImageChild(songPanel, "SongNumIndicator", new Vector2(28, 30), Path.Combine("Enso", "CurSongIndicator" + (i + 1) + ".png"));
 
 
 
@@ -443,11 +433,11 @@ namespace DaniDojo.Assets
 
                 // Create the requirement bars
 
-                var barData = DaniPlayManager.GetBorderBarData(border, play, i);
+                var barData = DaniPlayManager.GetBorderBarData(border, play, songNumber: i, remainingNotes: 0);
                 var bar = AssetUtility.CreateEmptyObject(songPanel, "RequirementBar", new Vector2(-264, 13));
 
                 Vector2 barPosition = new Vector2(389, 15);
-                AssetUtility.CreateImageChild(bar, "CurReqBar", barPosition, Path.Combine(AssetFilePath, "Results", "ResultsBorderFillSmall.png"));
+                AssetUtility.CreateImageChild(bar, "CurReqBar", barPosition, Path.Combine("Results", "ResultsBorderFillSmall.png"));
 
                 Rect fillBarRect = new Rect(393, 24, 322, 41);
                 var fillBar = AssetUtility.CreateImageChild(bar, "CurReqBarFill", fillBarRect, barData.Color);
@@ -457,7 +447,7 @@ namespace DaniDojo.Assets
                 var emptyBar = AssetUtility.CreateImageChild(bar, "CurReqBarEmpty", emptyBarRect, BorderBarColors.BorderBarColor[BorderBarState.Grey]);
 
                 Vector2 borderBarRect = new Vector2(389, 22);
-                AssetUtility.CreateImageChild(bar, "CurReqBarBorder", borderBarRect, Path.Combine(AssetFilePath, "Results", "ResultsBorderSmall.png"));
+                AssetUtility.CreateImageChild(bar, "CurReqBarBorder", borderBarRect, Path.Combine("Results", "ResultsBorderSmall.png"));
 
 
                 Plugin.LogInfo("barData.FillRatio: " + barData.FillRatio);
@@ -483,7 +473,7 @@ namespace DaniDojo.Assets
 
                 var barState = DigitAssets.GetRequirementBarState(barData, border);
                 DigitAssets.CreateRequirementBarNumber(bar, new Vector2(397, 29), barData.PlayValue, RequirementBarType.Medium, barState);
-                
+
 
                 // Create the requirement value string
                 var requirementValueString = string.Empty;

--- a/DaniDojo/Data/CourseData.cs
+++ b/DaniDojo/Data/CourseData.cs
@@ -39,6 +39,7 @@ namespace DaniDojo.Data
     public enum DaniCourseLevel
     {
         None,
+        kyuuFirst,
         kyuu10,
         kyuu9,
         kyuu8,
@@ -72,6 +73,8 @@ namespace DaniDojo.Data
         public DaniSeries Parent { get; set; }
         public string Id { get; set; }
         public string Title { get; set; }
+        public string JpTitle { get; set; }
+        public string EngTitle { get; set; }
         public int Order { get; set; }
         public bool IsLocked { get; set; }
         public CourseBackground Background { get; set; }

--- a/DaniDojo/Data/DaniSaveData.cs
+++ b/DaniDojo/Data/DaniSaveData.cs
@@ -40,6 +40,10 @@ namespace DaniDojo.Data
         {
             Rank = newRank;
             Combo = newCombo;
+            if (newCombo == DaniCombo.None)
+            {
+                Rank = DaniRank.None;
+            }
         }
 
         public bool Equals(DaniRankCombo other)
@@ -117,7 +121,8 @@ namespace DaniDojo.Data
     {
         public uint Hash { get; set; }
         private DaniCourse _course;
-        public DaniCourse Course { 
+        public DaniCourse Course
+        {
             get
             {
                 if (_course == null)
@@ -125,11 +130,12 @@ namespace DaniDojo.Data
                     _course = CourseDataManager.GetCourseFromHash(Hash);
                 }
                 return _course;
-            } 
+            }
             set
             {
                 _course = value;
-            } }
+            }
+        }
         public DaniRankCombo RankCombo { get; set; }
         public List<PlayData> PlayData { get; set; }
         public int SongReached { get; set; } // 1 indexed, where 0 means no song played

--- a/DaniDojo/Hooks/HitResultHook.cs
+++ b/DaniDojo/Hooks/HitResultHook.cs
@@ -1,0 +1,118 @@
+﻿using Blittables;
+using DaniDojo.Data;
+using DaniDojo.Managers;
+using DaniDojo.Patches;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static TaikoCoreTypes;
+
+namespace DaniDojo.Hooks
+{
+    internal class HitResultHook
+    {
+        #region Note Counting
+        //[HarmonyPatch(typeof(HitEffect))]
+        //[HarmonyPatch(nameof(HitEffect.switchPlayAnimationOnpuTypes))]
+        //[HarmonyPatch(MethodType.Normal)]
+        //[HarmonyPostfix]
+        //public static void HitEffect_switchPlayAnimationOnpuTypes_Postfix(HitEffect __instance, HitResultInfo info)
+        //{
+        //    if (DaniPlayManager.CheckIsInDan())
+        //    {
+        //        DaniPlayManager.AddHitResult(info);
+        //        int hitResult = info.hitResult;
+        //        if (info.onpuType == (int)OnpuTypes.Don || info.onpuType == (int)OnpuTypes.Do || info.onpuType == (int)OnpuTypes.Ko || info.onpuType == (int)OnpuTypes.Katsu || info.onpuType == (int)OnpuTypes.Ka
+        //            || info.onpuType == (int)OnpuTypes.DaiDon || info.onpuType == (int)OnpuTypes.DaiKatsu
+        //            || info.onpuType == (int)OnpuTypes.WDon || info.onpuType == (int)OnpuTypes.WKatsu)
+        //        {
+        //            if (hitResult == (int)HitResultTypes.Fuka || hitResult == (int)HitResultTypes.Drop)
+        //            {
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Bads);
+        //            }
+        //            else if (hitResult == (int)HitResultTypes.Ka)
+        //            {
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Oks);
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Combo);
+        //            }
+        //            else if (hitResult == (int)HitResultTypes.Ryo)
+        //            {
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Goods);
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Combo);
+        //            }
+        //        }
+        //        else if (info.onpuType == (int)OnpuTypes.Renda || info.onpuType == (int)OnpuTypes.DaiRenda || info.onpuType == (int)OnpuTypes.Imo || info.onpuType == (int)OnpuTypes.GekiRenda)
+        //        {
+        //            if (hitResult == (int)HitResultTypes.Ryo)
+        //            {
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+        //                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Drumroll);
+        //            }
+        //        }
+        //    }
+        //}
+
+
+        [HarmonyPatch(typeof(EnsoGameManager))]
+        [HarmonyPatch(nameof(EnsoGameManager.ProcExecMain))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPostfix]
+        public static void EnsoGameManager_ProcExecMain_Postfix_GetNoteResults(EnsoGameManager __instance)
+        {
+            if (DaniPlayManager.CheckIsInDan())
+            {
+                var frameResult = __instance.ensoParam.GetFrameResults();
+                EachPlayer eachPlayer = frameResult.GetEachPlayer(0);
+                DaniPlayManager.AddHitResultFromEachPlayer(eachPlayer);
+                return;
+                Plugin.LogInfo("eachPlayer.countFuka: " + eachPlayer.countFuka);
+                for (int i = 0; i < frameResult.hitResultInfoNum - 1; i++)
+                {
+                    if (frameResult.hitResultInfo[i].player == 0)
+                    {
+                        var info = frameResult.hitResultInfo[i];
+
+                        DaniPlayManager.AddHitResult(info);
+                        int hitResult = info.hitResult;
+                        if (info.onpuType == (int)OnpuTypes.Don || info.onpuType == (int)OnpuTypes.Do || info.onpuType == (int)OnpuTypes.Ko || info.onpuType == (int)OnpuTypes.Katsu || info.onpuType == (int)OnpuTypes.Ka
+                            || info.onpuType == (int)OnpuTypes.DaiDon || info.onpuType == (int)OnpuTypes.DaiKatsu
+                            || info.onpuType == (int)OnpuTypes.WDon || info.onpuType == (int)OnpuTypes.WKatsu)
+                        {
+                            if (hitResult == (int)HitResultTypes.Fuka || hitResult == (int)HitResultTypes.Drop)
+                            {
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Bads);
+                            }
+                            else if (hitResult == (int)HitResultTypes.Ka)
+                            {
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Oks);
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Combo);
+                            }
+                            else if (hitResult == (int)HitResultTypes.Ryo)
+                            {
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Goods);
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Combo);
+                            }
+                        }
+                        else if (info.onpuType == (int)OnpuTypes.Renda || info.onpuType == (int)OnpuTypes.DaiRenda)
+                        {
+                            if (hitResult == (int)HitResultTypes.Ryo)
+                            {
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Drumroll);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DaniDojo/Hooks/LoadingScreenHook.cs
+++ b/DaniDojo/Hooks/LoadingScreenHook.cs
@@ -1,0 +1,145 @@
+﻿using DaniDojo.Assets;
+using DaniDojo.Managers;
+using DaniDojo.Patches;
+using HarmonyLib;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace DaniDojo.Hooks
+{
+    internal class LoadingScreenHook
+    {
+        [HarmonyPatch(typeof(LoadingScript))]
+        [HarmonyPatch(nameof(LoadingScript.SetLoadingCanvasIn))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool LoadingScript_SetLoadingCanvasIn_Prefix(LoadingScript __instance)
+        {
+            Plugin.LogInfo("In");
+            if (DaniPlayManager.CheckIsInDan() || DaniPlayManager.CheckStartResult())
+            {
+                __instance.isDisplaying = true;
+                //__instance.setAlphaCanvasGroup(true, true, false);
+                //__instance.setLoadingCanvasType(LoadingScript.LoadingTypeName.LoadingSong);
+                TaikoSingletonMonoBehaviour<InputGuide>.Instance.DisableGuide();
+                __instance.setManager();
+                //__instance.animPlayClip(LoadingScript.LoadingAnimType.LoadingIcon, 2, null);
+                __instance.StartCoroutine(LoadDaniEnso(__instance));
+
+                __instance.isAnimPlayed = true;
+                return false;
+            }
+            else
+            {
+                var daniLoading = AssetUtility.GetChildByName(__instance.canvasGroups[0].gameObject, "DaniLoading");
+                GameObject.Destroy(daniLoading);
+            }
+            return true;
+        }
+
+        static GameObject DaniLoadingCanvasGroup;
+        public static IEnumerator LoadDaniEnso(LoadingScript __instance)
+        {
+            EndLoading = false;
+            var daniParent = AssetUtility.CreateEmptyObject(__instance.canvasGroups[0].gameObject, "DaniLoading", Vector2.zero);
+            var loadingBg = AssetUtility.CreateImageChild(daniParent, "DaniEnsoLoadingBg", new Vector2(0, 1080 - 1300), Path.Combine("Loading", "LoadingEnsoBg.png"));
+            CommonAssets.CreateDaniCourse(daniParent, new Vector2(1570, 489), DaniPlayManager.GetCurrentCourse());
+            yield return AssetUtility.MoveOverSeconds(loadingBg, Vector2.zero, 3);
+            yield return new WaitForSeconds(1.25f);
+
+            EndLoading = true;
+        }
+
+
+
+        [HarmonyPatch(typeof(LoadingScript))]
+        [HarmonyPatch(nameof(LoadingScript.SetLoadingCanvasOut))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool LoadingScript_SetLoadingCanvasOut_Prefix(LoadingScript __instance)
+        {
+            Plugin.LogInfo("Out");
+            if (DaniPlayManager.CheckIsInDan() || DaniPlayManager.CheckStartResult())
+            {
+                __instance.setLoadingCanvasOut(LoadingScript.LoadingTypeName.LoadingSong, delegate (bool result)
+                {
+                    if (result)
+                    {
+                        //__instance.setAlphaCanvasGroup(false, false, false);
+                        __instance.isDisplaying = false;
+                    }
+                });
+                return false;
+            }
+            return true;
+        }
+
+        [HarmonyPatch(typeof(LoadingScript))]
+        [HarmonyPatch(nameof(LoadingScript.setLoadingCanvasOut))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool LoadingScript_setLoadingCanvasOut_Prefix(LoadingScript __instance, LoadingScript.BoolDelegate callback)
+        {
+            Plugin.LogInfo("out");
+            if (DaniPlayManager.CheckIsInDan() || DaniPlayManager.CheckStartResult())
+            {
+                __instance.setAlphaCanvasGroup(false, false, false);
+                __instance.isAnimPlayed = false;
+
+                __instance.StartCoroutine(WaitForSeconds(5, callback));
+
+                return false;
+            }
+            return true;
+        }
+
+        public static bool EndLoading = false;
+
+        [HarmonyPatch(typeof(EnsoGameManager))]
+        [HarmonyPatch(nameof(EnsoGameManager.ProcPreparing))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool EnsoGameManager_ProcPreparing_Prefix(EnsoGameManager __instance)
+        {
+            if (DaniPlayManager.CheckIsInDan() || DaniPlayManager.CheckStartResult())
+            {
+                return EndLoading;
+            }
+            return true;
+        }
+
+        internal static IEnumerator WaitForSeconds(float sec, LoadingScript.BoolDelegate callback)
+        {
+            yield return new WaitForSeconds(sec);
+            if (callback != null)
+            {
+                callback(true);
+            }
+            yield break;
+        }
+
+        [HarmonyPatch(typeof(EnsoGameManager))]
+        [HarmonyPatch(nameof(EnsoGameManager.ProcExecMain))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool EnsoGameManager_ProcExecMain_Prefix(EnsoGameManager __instance)
+        {
+            return !DaniDojoTempEnso.EnsoPause;
+        }
+
+        [HarmonyPatch(typeof(EnsoSound))]
+        [HarmonyPatch(nameof(EnsoSound.PlaySong))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool EnsoSound_PlaySong_Prefix(EnsoGameManager __instance)
+        {
+            return !DaniDojoTempEnso.EnsoPause;
+        }
+    }
+}

--- a/DaniDojo/Hooks/ResultsHook.cs
+++ b/DaniDojo/Hooks/ResultsHook.cs
@@ -13,6 +13,7 @@ namespace DaniDojo.Hooks
 {
     internal class ResultsHook
     {
+        // Go into the dani results screen instead of the normal results screen
         [HarmonyPatch(typeof(EnsoGameManager))]
         [HarmonyPatch(nameof(EnsoGameManager.ProcResult))]
         [HarmonyPatch(MethodType.Normal)]
@@ -21,6 +22,7 @@ namespace DaniDojo.Hooks
         {
             if (__instance.stateTimer == 1 && (DaniPlayManager.CheckIsInDan() || DaniPlayManager.CheckStartResult()))
             {
+                //__instance.graphicManager.SetActiveStateFade();
                 GameObject ResultsParent = GameObject.Find("DaniResults");
                 if (ResultsParent == null)
                 {
@@ -38,5 +40,20 @@ namespace DaniDojo.Hooks
 
             return true;
         }
+
+        // Don't save any results from this play
+        [HarmonyPatch(typeof(EnsoGameManager))]
+        [HarmonyPatch(nameof(EnsoGameManager.SetResults))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool EnsoGameManager_SetResults_Prefix(EnsoGameManager __instance)
+        {
+            if (DaniPlayManager.CheckIsInDan() || DaniPlayManager.CheckStartResult())
+            {
+                return false;
+            }
+            return true;
+        }
+
     }
 }

--- a/DaniDojo/Hooks/ScoreUpdateHook.cs
+++ b/DaniDojo/Hooks/ScoreUpdateHook.cs
@@ -20,7 +20,20 @@ namespace DaniDojo.Hooks
             {
                 DaniPlayManager.AddScore(score);
             }
-            
+
+            return true;
+        }
+
+        [HarmonyPatch(typeof(ScorePlayer))]
+        [HarmonyPatch(nameof(ScorePlayer.SetScore))]
+        [HarmonyPatch(MethodType.Normal)]
+        [HarmonyPrefix]
+        public static bool ScorePlayer_SetScore_Prefix(ScorePlayer __instance, ref int score)
+        {
+            if (DaniPlayManager.CheckIsInDan())
+            {
+                score = DaniPlayManager.GetCurrentPlay().SongPlayData.Sum(x => x.Score);
+            }
             return true;
         }
     }

--- a/DaniDojo/Hooks/TestingHooks.cs
+++ b/DaniDojo/Hooks/TestingHooks.cs
@@ -38,5 +38,21 @@ namespace DaniDojo.Hooks
 
         //    return true;
         //}
+
+        //[HarmonyPatch(typeof(EnsoGameManager))]
+        //[HarmonyPatch(nameof(EnsoGameManager.ProcExecMain))]
+        //[HarmonyPatch(MethodType.Normal)]
+        //[HarmonyPrefix]
+        //public static bool EnsoGameManager_ProcExecMain_Prefix(EnsoGameManager __instance)
+        //{
+        //    Plugin.LogInfo("__instance.ensoParam.TotalTime: " + __instance.ensoParam.TotalTime + "\n" +
+        //                   "__instance.totalTime: " + __instance.totalTime + "\n" +
+        //                   "__instance.ensoSound.GetSongPosition(): " + __instance.ensoSound.GetSongPosition() + "\n" +
+        //                   "__instance.adjustCounter: " + __instance.adjustCounter + "\n" +
+        //                   "__instance.adjustSubTime: " + __instance.adjustSubTime + "\n" +
+        //                   "__instance.adjustTime: " + __instance.adjustTime + "\n", 1);
+
+        //    return true;
+        //}
     }
 }

--- a/DaniDojo/Managers/CourseDataManager.cs
+++ b/DaniDojo/Managers/CourseDataManager.cs
@@ -80,7 +80,21 @@ namespace DaniDojo.Managers
             //Plugin.LogInfo("Loading Course start", true);
             DaniCourse course = new DaniCourse();
             course.Id = node["Id"].GetValue<string>();
-            course.Title = node["Title"].GetValue<string>();
+            course.Title = course.Id;
+            course.JpTitle = string.Empty;
+            course.EngTitle = string.Empty;
+            if (node["Title"] != null)
+            {
+                course.Title = node["Title"].GetValue<string>();
+            }
+            if (node["JpTitle"] != null)
+            {
+                course.JpTitle = node["JpTitle"].GetValue<string>();
+            }
+            if (node["EngTitle"] != null)
+            {
+                course.EngTitle = node["EngTitle"].GetValue<string>();
+            }
             course.Order = node["Order"].GetValue<int>();
 
             course.IsLocked = node["IsLocked"].GetValue<bool>();
@@ -97,13 +111,23 @@ namespace DaniDojo.Managers
                     case "Red": course.Background = CourseBackground.Red; break;
                     case "Silver": course.Background = CourseBackground.Silver; break;
                     case "Gold": course.Background = CourseBackground.Gold; break;
-                    default: course.Background = CourseBackground.Tan; break;
+                    case "Gaiden": course.Background = CourseBackground.Gaiden; break;
+                    default: course.Background = CourseBackground.Sousaku; break;
+                }
+                if (course.Background == CourseBackground.Gaiden)
+                {
+                    course.CourseLevel = DaniCourseLevel.gaiden;
+                }
+                else if (course.Background == CourseBackground.Sousaku)
+                {
+                    course.CourseLevel = DaniCourseLevel.sousaku;
                 }
             }
             else
             {
                 switch (course.CourseLevel)
                 {
+                    case DaniCourseLevel.kyuuFirst:
                     case DaniCourseLevel.kyuu10:
                     case DaniCourseLevel.kyuu9:
                     case DaniCourseLevel.kyuu8:
@@ -436,7 +460,7 @@ namespace DaniDojo.Managers
                         course.Background = CourseBackground.Tan;
                         break;
                 }
-                
+
 
             }
 
@@ -660,36 +684,47 @@ namespace DaniDojo.Managers
         {
             switch (title.ToLower())
             {
+                case "1stkyu":
                 case "1stkyuu":
-                case "初級 First Kyu":
-                    return DaniCourseLevel.kyuu5;
+                case "初級 first kyu":
+                    return DaniCourseLevel.kyuuFirst;
+                case "10kyu":
                 case "10kyuu":
-                case "十級 10th Kyu":
-                    return DaniCourseLevel.kyuu5;
+                case "十級 10th kyu":
+                    return DaniCourseLevel.kyuu10;
+                case "9kyu":
                 case "9kyuu":
-                case "九級 9th Kyu":
-                    return DaniCourseLevel.kyuu5;
+                case "九級 9th kyu":
+                    return DaniCourseLevel.kyuu9;
+                case "8kyu":
                 case "8kyuu":
                 case "八級 8th kyu":
-                    return DaniCourseLevel.kyuu5;
+                    return DaniCourseLevel.kyuu8;
+                case "7kyu":
                 case "7kyuu":
                 case "七級 7th kyu":
-                    return DaniCourseLevel.kyuu5;
+                    return DaniCourseLevel.kyuu7;
+                case "6kyu":
                 case "6kyuu":
                 case "六級 6th kyu":
-                    return DaniCourseLevel.kyuu5;
+                    return DaniCourseLevel.kyuu6;
+                case "5kyu":
                 case "5kyuu":
                 case "五級 5th kyu":
                     return DaniCourseLevel.kyuu5;
+                case "4kyu":
                 case "4kyuu":
                 case "四級 4th kyu":
                     return DaniCourseLevel.kyuu4;
+                case "3kyu":
                 case "3kyuu":
                 case "三級 3rd kyu":
                     return DaniCourseLevel.kyuu3;
+                case "2kyu":
                 case "2kyuu":
                 case "二級 2nd kyu":
                     return DaniCourseLevel.kyuu2;
+                case "1kyu":
                 case "1kyuu":
                 case "一級 1st kyu":
                     return DaniCourseLevel.kyuu1;
@@ -724,19 +759,21 @@ namespace DaniDojo.Managers
                 case "十段 10th dan":
                     return DaniCourseLevel.dan10;
                 case "11dan":
+                case "kuroto":
                 case "玄人 kuroto":
                     return DaniCourseLevel.kuroto;
                 case "12dan":
+                case "meijin":
                 case "名人 meijin":
                     return DaniCourseLevel.meijin;
                 case "13dan":
+                case "chojin":
                 case "超人 chojin":
                     return DaniCourseLevel.chojin;
                 case "14dan":
+                case "tatsujin":
                 case "達人 tatsujin":
                     return DaniCourseLevel.tatsujin;
-                case "gaiden":
-                    return DaniCourseLevel.gaiden;
                 default:
                     return DaniCourseLevel.sousaku;
             }

--- a/DaniDojo/Managers/DaniPlayManager.cs
+++ b/DaniDojo/Managers/DaniPlayManager.cs
@@ -312,6 +312,38 @@ namespace DaniDojo.Managers
             }
         }
 
+        static public void AddHitResultFromEachPlayer(EachPlayer player)
+        {
+            var songPlayData = currentPlay.PlayData.SongPlayData[currentPlay.CurrentSongIndex];
+            if (songPlayData.Goods != (int)player.countRyo)
+            {
+                songPlayData.Goods = (int)player.countRyo;
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Goods);
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+                AddCombo();
+            }
+            if (songPlayData.Oks != (int)player.countKa)
+            {
+                songPlayData.Oks = (int)player.countKa;
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Oks);
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+                AddCombo();
+            }
+            if (songPlayData.Bads != (int)player.countFuka)
+            {
+                songPlayData.Bads = (int)player.countFuka;
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Bads);
+                currentPlay.CurrentSongCombo = 0;
+                currentPlay.CurrentCombo = 0;
+            }
+            if (songPlayData.Drumroll != (int)player.countRenda)
+            {
+                songPlayData.Drumroll = (int)player.countRenda;
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Drumroll);
+                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.TotalHits);
+            }
+        }
+
         static void AddGood()
         {
             var songPlayData = currentPlay.PlayData.SongPlayData[currentPlay.CurrentSongIndex];
@@ -335,6 +367,7 @@ namespace DaniDojo.Managers
             currentPlay.CurrentCombo++;
             currentPlay.PlayData.MaxCombo = Math.Max(currentPlay.PlayData.MaxCombo, currentPlay.CurrentCombo);
             songPlayData.Combo = Math.Max(currentPlay.CurrentSongCombo, songPlayData.Combo);
+            DaniDojoAssets.EnsoAssets.UpdateRequirementBar(BorderType.Combo);
         }
 
         static public void AddScore(int points)
@@ -478,7 +511,7 @@ namespace DaniDojo.Managers
         static DaniRank CalculateBorder(DaniBorder border, PlayData play)
         {
             var playValues = GetBorderPlayResults(border, play);
-            if (playValues.Count > border.RedReqs.Count || 
+            if (playValues.Count > border.RedReqs.Count ||
                 playValues.Count > border.GoldReqs.Count)
             {
                 Plugin.LogError("CalculateBorder Error: Too many values in PlayValues compared to Border Requirements.");
@@ -541,12 +574,12 @@ namespace DaniDojo.Managers
                 switch (border.BorderType)
                 {
                     //case BorderType.SoulGauge: playResults.Add(play.SoulGauge); break; // Soul Gauge will take some time to figure out properly
-                    case BorderType.Goods:     playResults.Add(play.SongPlayData.Sum((x) => x.Goods)); break;
-                    case BorderType.Oks:       playResults.Add(play.SongPlayData.Sum((x) => x.Oks)); break;
-                    case BorderType.Bads:      playResults.Add(play.SongPlayData.Sum((x) => x.Bads)); break;
-                    case BorderType.Combo:     playResults.Add(play.MaxCombo); break;
-                    case BorderType.Drumroll:  playResults.Add(play.SongPlayData.Sum((x) => x.Drumroll)); break;
-                    case BorderType.Score:     playResults.Add(play.SongPlayData.Sum((x) => x.Score)); break;
+                    case BorderType.Goods: playResults.Add(play.SongPlayData.Sum((x) => x.Goods)); break;
+                    case BorderType.Oks: playResults.Add(play.SongPlayData.Sum((x) => x.Oks)); break;
+                    case BorderType.Bads: playResults.Add(play.SongPlayData.Sum((x) => x.Bads)); break;
+                    case BorderType.Combo: playResults.Add(play.MaxCombo); break;
+                    case BorderType.Drumroll: playResults.Add(play.SongPlayData.Sum((x) => x.Drumroll)); break;
+                    case BorderType.Score: playResults.Add(play.SongPlayData.Sum((x) => x.Score)); break;
                     case BorderType.TotalHits: playResults.Add(play.SongPlayData.Sum((x) => x.Goods + x.Oks + x.Drumroll)); break;
                 }
             }
@@ -556,12 +589,12 @@ namespace DaniDojo.Managers
                 {
                     switch (border.BorderType)
                     {
-                        case BorderType.Goods:     playResults.Add(play.SongPlayData[i].Goods); break;
-                        case BorderType.Oks:       playResults.Add(play.SongPlayData[i].Oks); break;
-                        case BorderType.Bads:      playResults.Add(play.SongPlayData[i].Bads); break;
-                        case BorderType.Combo:     playResults.Add(play.SongPlayData[i].Combo); break;
-                        case BorderType.Drumroll:  playResults.Add(play.SongPlayData[i].Drumroll); break;
-                        case BorderType.Score:     playResults.Add(play.SongPlayData[i].Score); break;
+                        case BorderType.Goods: playResults.Add(play.SongPlayData[i].Goods); break;
+                        case BorderType.Oks: playResults.Add(play.SongPlayData[i].Oks); break;
+                        case BorderType.Bads: playResults.Add(play.SongPlayData[i].Bads); break;
+                        case BorderType.Combo: playResults.Add(play.SongPlayData[i].Combo); break;
+                        case BorderType.Drumroll: playResults.Add(play.SongPlayData[i].Drumroll); break;
+                        case BorderType.Score: playResults.Add(play.SongPlayData[i].Score); break;
                         case BorderType.TotalHits: playResults.Add(play.SongPlayData[i].Goods + play.SongPlayData[i].Oks + play.SongPlayData[i].Drumroll); break;
                     }
                 }
@@ -703,6 +736,12 @@ namespace DaniDojo.Managers
                     }
                 }
 
+                if (playValue < goldReq && remainingNotes == 0)
+                {
+                    data.State = BorderBarState.Rainbow;
+                    data.FlashState = BorderBarFlashState.None;
+                }
+
             }
             return data;
         }
@@ -739,6 +778,6 @@ namespace DaniDojo.Managers
                 return DaniCombo.Silver;
             }
         }
-    
+
     }
 }

--- a/DaniDojo/Managers/DaniSoundManager.cs
+++ b/DaniDojo/Managers/DaniSoundManager.cs
@@ -14,7 +14,7 @@ namespace DaniDojo.Managers
         static string AssetFilePath => Plugin.Instance.ConfigDaniDojoAssetLocation.Value;
 
         static private CriPlayer bgmPlayer;
-        static private Dictionary<string, CriPlayer> players = new Dictionary<string, CriPlayer>(); 
+        static private Dictionary<string, CriPlayer> players = new Dictionary<string, CriPlayer>();
 
         static public void SetupBgm(string fileName, bool isLoop)
         {
@@ -52,7 +52,7 @@ namespace DaniDojo.Managers
             {
                 player = players[fileName];
             }
-            Plugin.Instance.StartCoroutine(PlayProcess(player, "intro", TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Se)));
+            Plugin.Instance.StartCoroutine(PlayProcess(player, "song_trance", TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Se)));
         }
 
         static public void StopSound(string fileName)
@@ -118,11 +118,12 @@ namespace DaniDojo.Managers
             {
                 return;
             }
-            player.Player.Stop(true);
+            player.Player.Stop(false);
         }
 
         static private IEnumerator PlayProcess(CriPlayer player, string cueKey, float volume)
         {
+            Plugin.LogInfo("PlayProcess: " + cueKey);
             yield return new WaitWhile(() => player.CheckLoading());
             StopSound(player);
             player.Player.SetVolume(volume);

--- a/DaniDojo/Managers/ResultsManager.cs
+++ b/DaniDojo/Managers/ResultsManager.cs
@@ -48,7 +48,7 @@ namespace DaniDojo.Managers
                 GetInput();
             }
 
-                
+
             public void GetInput()
             {
                 ControllerManager.Dir dir = TaikoSingletonMonoBehaviour<ControllerManager>.Instance.GetDirectionButton(ControllerManager.ControllerPlayerNo.Player1, ControllerManager.Prio.None, false);
@@ -94,6 +94,7 @@ namespace DaniDojo.Managers
                 var borders = ResultsAssets.CreateBorderPanels(PlayRecordParent, currentCourse, currentPlay);
 
                 var danCourseIcon = ResultsAssets.CreateCourseIcon(bg, currentCourse);
+                var danCourseTitle = ResultsAssets.CreateCourseTitle(bg, currentCourse);
 
                 donCommon = Instantiate(DaniDojoSongSelect.donCommonObject);
                 playerName = Instantiate(DaniDojoSongSelect.playerNameObject);

--- a/DaniDojo/Managers/SaveDataManager.cs
+++ b/DaniDojo/Managers/SaveDataManager.cs
@@ -307,7 +307,7 @@ namespace DaniDojo.Managers
 
         #endregion
 
-		static public void AddPlayData(uint hash, PlayData play)
+        static public void AddPlayData(uint hash, PlayData play)
         {
             Plugin.LogInfo("AddPlayData", 1);
             for (int i = 0; i < SaveData.Courses.Count; i++)

--- a/DaniDojo/OldPatches/ColorLerp.cs
+++ b/DaniDojo/OldPatches/ColorLerp.cs
@@ -118,7 +118,7 @@ namespace DaniDojo.Patches
                         image.color = Color32.Lerp(data.Color, new Color32(255, 255, 255, 255), Mathf.PingPong(Time.time / intervalFast, intervalFast));
                     }
                 }
-               
+
 
                 if (isRainbow || isSmallRainbow || isSmallResultRainbow)
                 {
@@ -210,6 +210,15 @@ namespace DaniDojo.Patches
                 isSmallRainbow = false;
                 isSmallResultRainbow = true;
             }
+        }
+
+        public void EndRainbow()
+        {
+            isRainbow = false;
+            isSmallRainbow = false;
+            isSmallResultRainbow = false;
+            image = GetComponent<Image>();
+            image.sprite = null;
         }
 
         public void End()

--- a/DaniDojo/OldPatches/DaniDojoAssetUtility.cs
+++ b/DaniDojo/OldPatches/DaniDojoAssetUtility.cs
@@ -59,7 +59,7 @@ namespace DaniDojo.Patches
                 Plugin.Log.LogError("Could not find file: " + filePath);
                 return new GameObject(name);
             }
-            
+
             //var imageCanvas = newImageObj.AddComponent<Canvas>();
             //var parentCanvas = parent.gameObject.GetComponent<Canvas>();
             //imageCanvas.sortingOrder = sortOrder;

--- a/DaniDojo/OldPatches/DaniDojoAssets.cs
+++ b/DaniDojo/OldPatches/DaniDojoAssets.cs
@@ -11,34 +11,33 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.UIElements;
-using static DaniDojo.Patches.DaniDojoDaniCourseSelect;
 using Image = UnityEngine.UI.Image;
 
 namespace DaniDojo.Patches
 {
     internal static class DaniDojoAssets
     {
-        static string BaseImageFilePath => Plugin.Instance.ConfigDaniDojoAssetLocation.Value;
+        //static string BaseImageFilePath => Plugin.Instance.ConfigDaniDojoAssetLocation.Value;
 
 
-        static Color32 InvisibleColor = new Color32(0, 0, 0, 0);
+        //static Color32 InvisibleColor = new Color32(0, 0, 0, 0);
 
         static Color32 PinkBarColor = new Color32(254, 161, 183, 255);
-        static Color32 YellowBarColor = new Color32(249, 254, 55, 255);
-        static Color32 RedBarColor = new Color32(250, 124, 78, 255);
+        //static Color32 YellowBarColor = new Color32(249, 254, 55, 255);
+        //static Color32 RedBarColor = new Color32(250, 124, 78, 255);
         static Color32 GreyBarColor = new Color32(69, 69, 69, 255);
 
-        static Color32 GoldReqTextBorderColor = new Color32(221, 89, 56, 255);
-        static Color32 GoldReqTextFillColor = new Color32(255, 93, 127, 255);
-        static Color32 GoldReqTextTransparentColor = new Color32(255, 244, 45, 255);
+        //static Color32 GoldReqTextBorderColor = new Color32(221, 89, 56, 255);
+        //static Color32 GoldReqTextFillColor = new Color32(255, 93, 127, 255);
+        //static Color32 GoldReqTextTransparentColor = new Color32(255, 244, 45, 255);
 
-        static Color32 NormalTextBorderColor = new Color32(177, 177, 177, 255);
-        static Color32 NormalTextFillColor = new Color32(255, 255, 255, 255);
-        static Color32 NormalTextTransparentColor = new Color32(0, 0, 0, 0);
+        //static Color32 NormalTextBorderColor = new Color32(177, 177, 177, 255);
+        //static Color32 NormalTextFillColor = new Color32(255, 255, 255, 255);
+        //static Color32 NormalTextTransparentColor = new Color32(0, 0, 0, 0);
 
-        static Color32 ZeroTextBorderColor = new Color32(177, 177, 177, 255);
-        static Color32 ZeroTextFillColor = new Color32(0, 0, 0, 0);
-        static Color32 ZeroTextTransparentColor = new Color32(0, 0, 0, 0);
+        //static Color32 ZeroTextBorderColor = new Color32(177, 177, 177, 255);
+        //static Color32 ZeroTextFillColor = new Color32(0, 0, 0, 0);
+        //static Color32 ZeroTextTransparentColor = new Color32(0, 0, 0, 0);
 
         public static class EnsoAssets
         {
@@ -58,7 +57,7 @@ namespace DaniDojo.Patches
                 {
                     if (borders[j].BorderType != BorderType.SoulGauge)
                     {
-                        CreatePanel("Panel" + j, new Vector2(117, 353 - (159 * numPanels)), parent.transform, borders[j]);
+                        CreatePanel("Panel" + j, new Vector2(117, 353 - (159 * numPanels)), parent, borders[j]);
                         numPanels++;
                     }
                 }
@@ -80,16 +79,16 @@ namespace DaniDojo.Patches
                 {
                     gameObject = GameObject.Find("icon_course");
                 }
-                AssetUtility.ChangeImageSprite(gameObject, Path.Combine(BaseImageFilePath, "Course", "DifficultyIcons", "DaniDojoResized.png"));
+                AssetUtility.ChangeImageSprite(gameObject, Path.Combine("Course", "DifficultyIcons", "DaniDojoResized.png"));
                 //DaniDojoAssetUtility.ChangeSprite(gameObject, Path.Combine(BaseImageFilePath, "Course", "DifficultyIcons", "DaniDojoResized.png"));
                 gameObject.GetComponentInChildren<TextMeshProUGUI>().text = "Dan-i dojo";
             }
 
-            private static void CreatePanel(string name, Vector2 location, Transform parent, DaniBorder border)
+            private static void CreatePanel(string name, Vector2 location, GameObject parent, DaniBorder border)
             {
                 Plugin.Log.LogInfo("Create Panel");
-                var newPanel = DaniDojoAssetUtility.CreateImage(name, Path.Combine(BaseImageFilePath, "Enso", "RequirementPanel.png"), location, parent);
-
+                //var newPanel = DaniDojoAssetUtility.CreateImage(name, Path.Combine("Enso", "RequirementPanel.png"), location, parent);
+                var newPanel = AssetUtility.CreateImageChild(parent, name, location, Path.Combine("Enso", "RequirementPanel.png"));
 
                 string requirementText = "Goods";
 
@@ -128,27 +127,22 @@ namespace DaniDojo.Patches
                         break;
                 }
 
-                var requirementTypeText = DaniDojoAssetUtility.CreateText("RequirementTypeText", requirementText, new Rect(24, 109, 334, 36), reqTypefont, reqTypeFontMaterial, HorizontalAlignmentOptions.Center, new Color32(74, 64, 51, 255), newPanel.transform);
+                //var requirementTypeText = DaniDojoAssetUtility.CreateText("RequirementTypeText", requirementText, new Rect(24, 109, 334, 36), reqTypefont, reqTypeFontMaterial, HorizontalAlignmentOptions.Center, new Color32(74, 64, 51, 255), newPanel.transform);
+                var requirementTypeText = AssetUtility.CreateTextChild(newPanel, "RequirementTypeText", new Rect(24, 109, 334, 36), requirementText);
+                AssetUtility.SetTextFontAndMaterial(requirementTypeText, reqTypefont, reqTypeFontMaterial);
+                AssetUtility.SetTextAlignment(requirementTypeText, HorizontalAlignmentOptions.Center);
 
                 Plugin.Log.LogInfo("Create SongIndicators");
 
-                string songNumIndImagePath = Path.Combine("Enso", "CurSongIndicator1.png");
-                if (border.IsTotal)
+                string songNumIndImagePath = "CurSongIndicatorTotal.png";
+
+                if (!border.IsTotal)
                 {
-                    songNumIndImagePath = Path.Combine("Enso", "CurSongIndicatorTotal.png");
+                    songNumIndImagePath = "CurSongIndicator" + (DaniPlayManager.GetCurrentSongNumber() + 1) + ".png";
                 }
-                else
-                {
-                    if (DaniPlayManager.GetCurrentSongNumber() == 1)
-                    {
-                        songNumIndImagePath = Path.Combine("Enso", "CurSongIndicator2.png");
-                    }
-                    else if (DaniPlayManager.GetCurrentSongNumber() == 2)
-                    {
-                        songNumIndImagePath = Path.Combine("Enso", "CurSongIndicator3.png");
-                    }
-                }
-                DaniDojoAssetUtility.CreateImage("SongNumIndicator", Path.Combine(BaseImageFilePath, songNumIndImagePath), new Vector2(20, 34), newPanel.transform);
+
+                //DaniDojoAssetUtility.CreateImage("SongNumIndicator", Path.Combine("Enso", songNumIndImagePath), new Vector2(20, 34), newPanel.transform);
+                AssetUtility.CreateImageChild(newPanel, "SongNumIndicator", new Vector2(20, 34), Path.Combine("Enso", songNumIndImagePath));
 
                 Plugin.Log.LogInfo("Create Requirement Value Text");
 
@@ -179,20 +173,24 @@ namespace DaniDojo.Patches
                 TMP_FontAsset reqValuefont = fontManager.GetDescriptionFontAsset(DataConst.FontType.EFIGS);
                 Material reqValueFontMaterial = fontManager.GetDescriptionFontMaterial(DataConst.FontType.EFIGS, DataConst.DescriptionFontMaterialType.OutlineSongInfo);
 
-                var requirementValue = DaniDojoAssetUtility.CreateText("RequirementValue", requirementValueString, new Rect(28, 40, 334, 46), reqValuefont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), newPanel.transform);
+                //var requirementValue = DaniDojoAssetUtility.CreateText("RequirementValue", requirementValueString, new Rect(28, 40, 334, 46), reqValuefont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), newPanel.transform);
+                var requirementValue = AssetUtility.CreateTextChild(newPanel, "RequirementValue", new Rect(28, 40, 334, 46), requirementValueString);
+                AssetUtility.SetTextFontAndMaterial(requirementValue, reqValuefont, reqValueFontMaterial);
+                AssetUtility.SetTextAlignment(requirementValue, HorizontalAlignmentOptions.Right);
 
                 Plugin.Log.LogInfo("Create Requirement Bars");
 
 
-                var curReqBarImagePath = Path.Combine("Enso", "Bars", "RequirementBarPerSong.png");
-                var curReqBarBorderImagePath = Path.Combine("Enso", "Bars", "RequirementBarBorderPerSong.png");
+                var curReqBarImagePath = "RequirementBarPerSong.png";
+                var curReqBarBorderImagePath = "RequirementBarBorderPerSong.png";
                 if (border.IsTotal)
                 {
-                    curReqBarImagePath = Path.Combine("Enso", "Bars", "RequirementBarTotal.png");
-                    curReqBarBorderImagePath = Path.Combine("Enso", "Bars", "RequirementBarBorderTotal.png");
+                    curReqBarImagePath = "RequirementBarTotal.png";
+                    curReqBarBorderImagePath = "RequirementBarBorderTotal.png";
                 }
                 Vector2 barPositions = new Vector2(389, 20);
-                DaniDojoAssetUtility.CreateImage("CurReqBar", Path.Combine(BaseImageFilePath, curReqBarImagePath), barPositions, newPanel.transform);
+                //DaniDojoAssetUtility.CreateImage("CurReqBar", Path.Combine("Enso", "Bars", curReqBarImagePath), barPositions, newPanel.transform);
+                AssetUtility.CreateImageChild(newPanel, "CurReqBar", barPositions, Path.Combine("Enso", "Bars", curReqBarImagePath));
 
                 Rect fillBarRect;
                 Rect emptyBarRect;
@@ -206,32 +204,46 @@ namespace DaniDojo.Patches
                     fillBarRect = new Rect(396, 36, 642, 80);
                     emptyBarRect = new Rect(396 + 642, 36, 642, 80);
                 }
-                var fillBar = DaniDojoAssetUtility.CreateNewImage("CurReqBarFill", PinkBarColor, fillBarRect, newPanel.transform);
+                //var fillBar = DaniDojoAssetUtility.CreateNewImage("CurReqBarFill", PinkBarColor, fillBarRect, newPanel.transform);
+                var fillBar = AssetUtility.CreateImageChild(newPanel, "CurReqBarFill", fillBarRect, PinkBarColor);
                 fillBar.AddComponent<ColorLerp>();
 
 
-                var coverBar = DaniDojoAssetUtility.CreateNewImage("CurReqBarEmpty", GreyBarColor, emptyBarRect, newPanel.transform);
-                DaniDojoAssetUtility.CreateImage("CurReqBarBorder", Path.Combine(BaseImageFilePath, curReqBarBorderImagePath), barPositions, newPanel.transform);
+                //var coverBar = DaniDojoAssetUtility.CreateNewImage("CurReqBarEmpty", GreyBarColor, emptyBarRect, newPanel.transform);
+                var coverBar = AssetUtility.CreateImageChild(newPanel, "CurReqBarEmpty", emptyBarRect, GreyBarColor);
+
+                //DaniDojoAssetUtility.CreateImage("CurReqBarBorder", Path.Combine("Enso", "Bars", curReqBarBorderImagePath), barPositions, newPanel.transform);
+                AssetUtility.CreateImageChild(newPanel, "CurReqBarBorder", barPositions, Path.Combine("Enso", "Bars", curReqBarBorderImagePath));
 
                 Plugin.Log.LogInfo("Create Previous Song Requirement Bars");
 
                 if (!border.IsTotal)
                 {
-                    var prevSongTop = DaniDojoAssetUtility.CreateImage("PrevSongHitReqsBarTop", Path.Combine(BaseImageFilePath, "Enso", "Bars", "PrevSongHitReqs.png"), new Vector2(1083, 73), newPanel.transform);
-                    var prevSongBot = DaniDojoAssetUtility.CreateImage("PrevSongHitReqsBarBot", Path.Combine(BaseImageFilePath, "Enso", "Bars", "PrevSongHitReqs.png"), new Vector2(1083, 23), newPanel.transform);
+                    //var prevSongTop = DaniDojoAssetUtility.CreateImage("PrevSongHitReqsBarTop", Path.Combine("Enso", "Bars", "PrevSongHitReqs.png"), new Vector2(1083, 73), newPanel.transform);
+                    //var prevSongBot = DaniDojoAssetUtility.CreateImage("PrevSongHitReqsBarBot", Path.Combine("Enso", "Bars", "PrevSongHitReqs.png"), new Vector2(1083, 23), newPanel.transform);
+                    var prevSongTop = AssetUtility.CreateImageChild(newPanel, "PrevSongHitReqsBarTop", new Vector2(1083, 73), Path.Combine("Enso", "Bars", "PrevSongHitReqs.png"));
+                    var prevSongBot = AssetUtility.CreateImageChild(newPanel, "PrevSongHitReqsBarBot", new Vector2(1083, 23), Path.Combine("Enso", "Bars", "PrevSongHitReqs.png"));
+                    Plugin.Log.LogInfo("Create Previous Song Requirement Bars 1");
                     if (DaniPlayManager.GetCurrentSongNumber() >= 1)
                     {
-                        DaniDojoAssetUtility.CreateImage("PrevSongHitReqOneIndicator", Path.Combine(BaseImageFilePath, "Enso", "PrevSongIndicator1.png"), new Vector2(2, 10), prevSongTop.transform);
-                        DaniDojoAssetUtility.CreateImage("PrevSongHitReqOneBar", Path.Combine(BaseImageFilePath, "Enso", "Bars", "PrevSongBar.png"), new Vector2(44, 4), prevSongTop.transform);
-                        var prevSongBar1 = DaniDojoAssetUtility.CreateNewImage("PrevSongHitReqOneBarFill", PinkBarColor, new Rect(46, 11, 234, 33), prevSongTop.transform);
-                        DaniDojoAssetUtility.CreateImage("PrevSongHitReqOneBarBorder", Path.Combine(BaseImageFilePath, "Enso", "Bars", "PrevSongBarBorder.png"), new Vector2(44, 4), prevSongTop.transform);
+                        //DaniDojoAssetUtility.CreateImage("PrevSongHitReqOneIndicator", Path.Combine("Enso", "PrevSongIndicator1.png"), new Vector2(2, 10), prevSongTop.transform);
+                        //DaniDojoAssetUtility.CreateImage("PrevSongHitReqOneBar", Path.Combine("Enso", "Bars", "PrevSongBar.png"), new Vector2(44, 4), prevSongTop.transform);
+                        //var prevSongBar1 = DaniDojoAssetUtility.CreateNewImage("PrevSongHitReqOneBarFill", PinkBarColor, new Rect(46, 11, 234, 33), prevSongTop.transform);
+                        //DaniDojoAssetUtility.CreateImage("PrevSongHitReqOneBarBorder", Path.Combine("Enso", "Bars", "PrevSongBarBorder.png"), new Vector2(44, 4), prevSongTop.transform);
 
+                        AssetUtility.CreateImageChild(prevSongTop, "PrevSongHitReqOneIndicator", new Vector2(2, 10), Path.Combine("Enso", "PrevSongIndicator1.png"));
+                        AssetUtility.CreateImageChild(prevSongTop, "PrevSongHitReqOneBar", new Vector2(44, 4), Path.Combine("Enso", "PrevSongBar.png"));
+                        var prevSongBar1 = AssetUtility.CreateImageChild(prevSongTop, "PrevSongHitReqOneBarFill", new Rect(46, 11, 234, 33), PinkBarColor);
+                        AssetUtility.CreateImageChild(prevSongTop, "PrevSongHitReqOneBarBorder", new Vector2(44, 4), Path.Combine("Enso", "PrevSongBarBorder.png"));
+
+                        Plugin.Log.LogInfo("Create Previous Song Requirement Bars 2");
                         var songValues = DaniPlayManager.GetBorderPlayResults(border);
                         var image = prevSongBar1.GetOrAddComponent<Image>();
                         if (image != null)
                         {
                             BorderBarData songData1 = DaniPlayManager.GetBorderBarData(border, DaniPlayManager.GetCurrentPlay(), 0);
 
+                            Plugin.Log.LogInfo("Create Previous Song Requirement Bars 3");
                             var newScale = image.transform.localScale;
                             newScale.x = songData1.FillRatio / 100f;
 
@@ -242,8 +254,9 @@ namespace DaniDojo.Patches
 
                             if (songData1.State == BorderBarState.Rainbow)
                             {
-                                AssetUtility.ChangeImageSprite(image, Path.Combine(BaseImageFilePath, "Enso", "PrevSongRainbow", "PrevSongRainbow.png"));
+                                AssetUtility.ChangeImageSprite(image, Path.Combine("Enso", "PrevSongRainbow", "PrevSongRainbow.png"));
                             }
+                            Plugin.Log.LogInfo("Create Previous Song Requirement Bars 4");
 
                             var barState = DigitAssets.GetRequirementBarState(songData1, border);
                             DigitAssets.CreateRequirementBarNumber(prevSongTop, new Vector2(49, 15), songData1.PlayValue, RequirementBarType.Small, barState);
@@ -251,11 +264,17 @@ namespace DaniDojo.Patches
 
                         if (DaniPlayManager.GetCurrentSongNumber() >= 2)
                         {
-                            DaniDojoAssetUtility.CreateImage("PrevSongHitReqTwoIndicator", Path.Combine(BaseImageFilePath, "Enso", "PrevSongIndicator2.png"), new Vector2(2, 10), prevSongBot.transform);
-                            DaniDojoAssetUtility.CreateImage("PrevSongHitReqTwoBar", Path.Combine(BaseImageFilePath, "Enso", "Bars", "PrevSongBar.png"), new Vector2(44, 4), prevSongBot.transform);
-                            var prevSongBar2 = DaniDojoAssetUtility.CreateNewImage("PrevSongHitReqTwoBarFill", PinkBarColor, new Rect(46, 11, 234, 33), prevSongBot.transform);
-                            DaniDojoAssetUtility.CreateImage("PrevSongHitReqTwoBarBorder", Path.Combine(BaseImageFilePath, "Enso", "Bars", "PrevSongBarBorder.png"), new Vector2(44, 4), prevSongBot.transform);
+                            //DaniDojoAssetUtility.CreateImage("PrevSongHitReqTwoIndicator", Path.Combine("Enso", "PrevSongIndicator2.png"), new Vector2(2, 10), prevSongBot.transform);
+                            //DaniDojoAssetUtility.CreateImage("PrevSongHitReqTwoBar", Path.Combine("Enso", "Bars", "PrevSongBar.png"), new Vector2(44, 4), prevSongBot.transform);
+                            //var prevSongBar2 = DaniDojoAssetUtility.CreateNewImage("PrevSongHitReqTwoBarFill", PinkBarColor, new Rect(46, 11, 234, 33), prevSongBot.transform);
+                            //DaniDojoAssetUtility.CreateImage("PrevSongHitReqTwoBarBorder", Path.Combine("Enso", "Bars", "PrevSongBarBorder.png"), new Vector2(44, 4), prevSongBot.transform);
 
+                            AssetUtility.CreateImageChild(prevSongBot, "PrevSongHitReqTwoIndicator", new Vector2(2, 10), Path.Combine("Enso", "PrevSongIndicator1.png"));
+                            AssetUtility.CreateImageChild(prevSongBot, "PrevSongHitReqTwoBar", new Vector2(44, 4), Path.Combine("Enso", "PrevSongBar.png"));
+                            var prevSongBar2 = AssetUtility.CreateImageChild(prevSongBot, "PrevSongHitReqTwoBarFill", new Rect(46, 11, 234, 33), PinkBarColor);
+                            AssetUtility.CreateImageChild(prevSongBot, "PrevSongHitReqTwoBarBorder", new Vector2(44, 4), Path.Combine("Enso", "PrevSongBarBorder.png"));
+
+                            Plugin.Log.LogInfo("Create Previous Song Requirement Bars 5");
                             var image2 = prevSongBar2.GetOrAddComponent<Image>();
                             if (image2 != null)
                             {
@@ -270,8 +289,9 @@ namespace DaniDojo.Patches
 
                                 if (songData1.State == BorderBarState.Rainbow)
                                 {
-                                    AssetUtility.ChangeImageSprite(image2, Path.Combine(BaseImageFilePath, "Enso", "PrevSongRainbow", "PrevSongRainbow.png"));
+                                    AssetUtility.ChangeImageSprite(image2, Path.Combine("Enso", "PrevSongRainbow", "PrevSongRainbow.png"));
                                 }
+                                Plugin.Log.LogInfo("Create Previous Song Requirement Bars 6");
 
                                 var barState = DigitAssets.GetRequirementBarState(songData1, border);
                                 DigitAssets.CreateRequirementBarNumber(prevSongBot, new Vector2(49, 15), songData1.PlayValue, RequirementBarType.Small, barState);
@@ -281,12 +301,148 @@ namespace DaniDojo.Patches
                 }
             }
 
+            public static void AdvanceSongPanel(DaniCourse course, int songIndex)
+            {
+                int numPanels = 0;
+                for (int j = 0; j < course.Borders.Count && numPanels < 3; j++)
+                {
+                    if (course.Borders[j].BorderType != BorderType.SoulGauge)
+                    {
+                        var newPanel = GameObject.Find("Panel" + j);
+                        numPanels++;
+                        if (newPanel == null || course.Borders[j].IsTotal || songIndex == 0)
+                        {
+                            continue;
+                        }
+
+                        var mainFillBar = AssetUtility.GetChildByName(newPanel, "CurReqBarFill");
+                        var colorLerp = mainFillBar.GetOrAddComponent<ColorLerp>();
+                        colorLerp.EndRainbow();
+
+                        #region SetRequirementText
+
+                        var fontManager = GameObject.Find("FontTMPManager").GetComponent<FontTMPManager>();
+
+                        var requirementValueString = string.Empty;
+                        if (course.Borders[j].BorderType == BorderType.Oks || course.Borders[j].BorderType == BorderType.Bads)
+                        {
+                            requirementValueString = "Less than " + course.Borders[j].RedReqs[songIndex];
+                        }
+                        else
+                        {
+                            requirementValueString = course.Borders[j].RedReqs[songIndex] + " or more";
+                        }
+
+                        TMP_FontAsset reqValuefont = fontManager.GetDescriptionFontAsset(DataConst.FontType.EFIGS);
+                        Material reqValueFontMaterial = fontManager.GetDescriptionFontMaterial(DataConst.FontType.EFIGS, DataConst.DescriptionFontMaterialType.OutlineSongInfo);
+
+                        //var requirementValue = DaniDojoAssetUtility.CreateText("RequirementValue", requirementValueString, new Rect(28, 40, 334, 46), reqValuefont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), newPanel.transform);
+                        var requirementValue = AssetUtility.GetChildByName(newPanel, "RequirementValue");
+                        if (requirementValue == null)
+                        {
+                            requirementValue = AssetUtility.CreateTextChild(newPanel, "RequirementValue", new Rect(28, 40, 334, 46), requirementValueString);
+                        }
+                        requirementValue.GetOrAddComponent<TextMeshProUGUI>().text = requirementValueString;
+                        AssetUtility.SetTextFontAndMaterial(requirementValue, reqValuefont, reqValueFontMaterial);
+                        AssetUtility.SetTextAlignment(requirementValue, HorizontalAlignmentOptions.Right);
+
+                        #endregion
+
+                        var songNumIndImagePath = "CurSongIndicator" + (DaniPlayManager.GetCurrentSongNumber() + 1) + ".png";
+                        var songNumIndicator = AssetUtility.GetChildByName(newPanel, "SongNumIndicator");
+                        if (songNumIndicator == null)
+                        {
+                            AssetUtility.CreateImageChild(newPanel, "SongNumIndicator", new Vector2(20, 34), Path.Combine("Enso", songNumIndImagePath));
+                        }
+                        else
+                        {
+                            AssetUtility.ChangeImageSprite(songNumIndicator, Path.Combine("Enso", songNumIndImagePath));
+                        }
+
+                        //DaniDojoAssetUtility.CreateImage("SongNumIndicator", Path.Combine("Enso", songNumIndImagePath), new Vector2(20, 34), newPanel.transform);
+
+
+                        GameObject prevSongTop = AssetUtility.GetChildByName(newPanel, "PrevSongHitReqsBarTop");
+                        if (prevSongTop == null)
+                        {
+                            prevSongTop = AssetUtility.CreateImageChild(newPanel, "PrevSongHitReqsBarTop", new Vector2(1083, 73), Path.Combine("Enso", "Bars", "PrevSongHitReqs.png"));
+                        }
+
+                        GameObject prevSongBot = AssetUtility.GetChildByName(newPanel, "PrevSongHitReqsBarBot");
+                        if (prevSongBot == null)
+                        {
+                            prevSongBot = AssetUtility.CreateImageChild(newPanel, "PrevSongHitReqsBarBot", new Vector2(1083, 23), Path.Combine("Enso", "Bars", "PrevSongHitReqs.png"));
+                        }
+
+                        // If the songIndex is 1, we want to get the score for the 0 song to place in the top spot
+                        var parent = songIndex == 1 ? prevSongTop : prevSongBot;
+
+                        var prevSongIndicator = AssetUtility.GetChildByName(parent, "PrevSongHitReqOneIndicator");
+                        if (prevSongIndicator == null)
+                        {
+                            AssetUtility.CreateImageChild(parent, "PrevSongHitReqOneIndicator", new Vector2(2, 10), Path.Combine("Enso", "PrevSongIndicator" + songIndex + ".png"));
+                        }
+
+                        var prevSongBar = AssetUtility.GetChildByName(parent, "PrevSongHitReqOneBar");
+                        if (prevSongBar == null)
+                        {
+                            AssetUtility.CreateImageChild(parent, "PrevSongHitReqOneBar", new Vector2(44, 4), Path.Combine("Enso", "Bars", "PrevSongBar.png"));
+                        }
+
+                        var prevSongBarFill = AssetUtility.GetChildByName(parent, "PrevSongHitReqOneBarFill");
+                        if (prevSongBarFill == null)
+                        {
+                            prevSongBarFill = AssetUtility.CreateImageChild(parent, "PrevSongHitReqOneBarFill", new Rect(46, 11, 234, 33), PinkBarColor);
+                        }
+
+                        var prevSongBorder = AssetUtility.GetChildByName(parent, "PrevSongHitReqOneBarBorder");
+                        if (prevSongBorder == null)
+                        {
+                            AssetUtility.CreateImageChild(parent, "PrevSongHitReqOneBarBorder", new Vector2(44, 4), Path.Combine("Enso", "Bars", "PrevSongBarBorder.png"));
+                        }
+
+
+                        var songValues = DaniPlayManager.GetBorderPlayResults(course.Borders[j]);
+                        var image = prevSongBarFill.GetOrAddComponent<Image>();
+                        if (image != null)
+                        {
+                            BorderBarData songData1 = DaniPlayManager.GetBorderBarData(course.Borders[j], DaniPlayManager.GetCurrentPlay(), songIndex - 1);
+
+                            var newScale = image.transform.localScale;
+                            newScale.x = songData1.FillRatio / 100f;
+
+                            newScale.x = Math.Max(newScale.x, 0);
+                            newScale.x = Math.Min(newScale.x, 1);
+                            image.transform.localScale = newScale;
+                            image.color = songData1.Color;
+
+                            if (songData1.State == BorderBarState.Rainbow)
+                            {
+                                AssetUtility.ChangeImageSprite(image, Path.Combine("Enso", "PrevSongRainbow", "PrevSongRainbow.png"));
+                            }
+
+                            var barState = DigitAssets.GetRequirementBarState(songData1, course.Borders[j]);
+                            DigitAssets.CreateRequirementBarNumber(parent, new Vector2(49, 15), songData1.PlayValue, RequirementBarType.Small, barState);
+                        }
+                    }
+                }
+
+                numPanels = 0;
+                for (int j = 0; j < course.Borders.Count && numPanels < 3; j++)
+                {
+                    if (course.Borders[j].BorderType != BorderType.SoulGauge)
+                    {
+                        UpdateRequirementBar(course.Borders[j].BorderType);
+                        numPanels++;
+                    }
+                }
+            }
+
             public static void UpdateRequirementBar(BorderType borderType)
             {
                 Plugin.LogInfo("UpdateRequirementBar Start", 2);
                 var indexes = DaniPlayManager.GetIndexexOfBorder(borderType);
                 var borders = DaniPlayManager.GetCurrentBorderOfType(borderType);
-                var currentValue = DaniPlayManager.GetCurrentBorderValue(borderType);
 
                 for (int j = 0; j < indexes.Count; j++)
                 {
@@ -294,16 +450,19 @@ namespace DaniDojo.Patches
                     GameObject panel = GameObject.Find("Panel" + indexes[j]);
                     if (panel != null)
                     {
+                        Plugin.LogInfo("UpdateRequirementBar: 1", 2);
                         //var bar = panel.transform.Find("CurReqBarFill");
-                        var bar = panel.transform.Find("CurReqBarFill").gameObject;
-                        var emptyBar = panel.transform.Find("CurReqBarEmpty").gameObject;
+                        var bar = AssetUtility.GetChildByName(panel, "CurReqBarFill");
+                        var emptyBar = AssetUtility.GetChildByName(panel, "CurReqBarEmpty");
                         if (bar != null && emptyBar != null)
                         {
+                            Plugin.LogInfo("UpdateRequirementBar: 2", 2);
                             var image = bar.GetOrAddComponent<Image>();
                             var emptyImage = emptyBar.GetOrAddComponent<Image>();
                             var colorLerp = bar.GetOrAddComponent<ColorLerp>();
                             BorderBarData data = DaniPlayManager.GetBorderBarData(borders[j], DaniPlayManager.GetCurrentPlay(), DaniPlayManager.GetCurrentSongNumber());
 
+                            Plugin.LogInfo("UpdateRequirementBar: 3", 2);
 
                             bool isGold = data.State == BorderBarState.Rainbow;
 
@@ -320,6 +479,7 @@ namespace DaniDojo.Patches
                                 colorLerp.UpdateState(data, borders[j].IsTotal);
                             }
 
+                            Plugin.LogInfo("UpdateRequirementBar: 4", 2);
 
                             ChangeReqCurrentValue(panel, data.PlayValue, isGold);
 
@@ -328,6 +488,7 @@ namespace DaniDojo.Patches
                             // Probably don't need this clamp anymore, but it shouldn't hurt to have it.
                             newScale.x = Math.Max(newScale.x, 0);
                             newScale.x = Math.Min(newScale.x, 1);
+                            Plugin.LogInfo("UpdateRequirementBar: 5", 2);
 
                             // Previously was resizing the filled area
                             // Currently resizing the empty area
@@ -335,6 +496,7 @@ namespace DaniDojo.Patches
                             newScale.x -= 1;
                             emptyImage.transform.localScale = newScale;
                             image.color = data.Color;
+                            Plugin.LogInfo("UpdateRequirementBar: 6", 2);
                         }
 
                         // Why is this even here?
@@ -421,339 +583,339 @@ namespace DaniDojo.Patches
             {
                 DigitAssets.CreateRequirementBarNumber(panel, new Vector2(403, 44), value, RequirementBarType.Large, isGold ? RequirementBarState.Gold : RequirementBarState.Normal);
                 return;
-                if (!Directory.Exists(Path.Combine(BaseImageFilePath, "Digits")))
-                {
-                    return;
-                }
-                InitializeDigitSpriteLists();
-                value = Mathf.Max(value, 0);
-                value = Mathf.Min(value, 99999999); // 99,999,999
-                string num = value.ToString();
-                for (int i = 0; i < "99999999".Length; i++)
-                {
-                    var numLocation = new Vector2(403 + (56 * i), 44);
-                    var baseNumberPath = Path.Combine(BaseImageFilePath, "Digits", "Big");
+                //if (!Directory.Exists(Path.Combine(BaseImageFilePath, "Digits")))
+                //{
+                //    return;
+                //}
+                //InitializeDigitSpriteLists();
+                //value = Mathf.Max(value, 0);
+                //value = Mathf.Min(value, 99999999); // 99,999,999
+                //string num = value.ToString();
+                //for (int i = 0; i < "99999999".Length; i++)
+                //{
+                //    var numLocation = new Vector2(403 + (56 * i), 44);
+                //    var baseNumberPath = Path.Combine(BaseImageFilePath, "Digits", "Big");
 
-                    var digitBorderTransform = panel.transform.Find("CurReqBarValueBorder" + i);
-                    var digitFillTransform = panel.transform.Find("CurReqBarValueFill" + i);
-                    var digitTransparentTransform = panel.transform.Find("CurReqBarValueTransparent" + i);
-                    if (digitBorderTransform == null)
-                    {
-                        digitBorderTransform = DaniDojoAssetUtility.CreateImage("CurReqBarValueBorder" + i, Path.Combine(baseNumberPath, "Border", "0.png"), numLocation, panel.transform).transform;
-                    }
-                    if (digitFillTransform == null)
-                    {
-                        digitFillTransform = DaniDojoAssetUtility.CreateImage("CurReqBarValueFill" + i, Path.Combine(baseNumberPath, "NoBorder", "0.png"), numLocation, panel.transform).transform;
-                    }
-                    if (digitTransparentTransform == null)
-                    {
-                        digitTransparentTransform = DaniDojoAssetUtility.CreateImage("CurReqBarValueTransparent" + i, Path.Combine(baseNumberPath, "Transparent", "0.png"), numLocation, panel.transform).transform;
-                    }
+                //    var digitBorderTransform = panel.transform.Find("CurReqBarValueBorder" + i);
+                //    var digitFillTransform = panel.transform.Find("CurReqBarValueFill" + i);
+                //    var digitTransparentTransform = panel.transform.Find("CurReqBarValueTransparent" + i);
+                //    if (digitBorderTransform == null)
+                //    {
+                //        digitBorderTransform = DaniDojoAssetUtility.CreateImage("CurReqBarValueBorder" + i, Path.Combine(baseNumberPath, "Border", "0.png"), numLocation, panel.transform).transform;
+                //    }
+                //    if (digitFillTransform == null)
+                //    {
+                //        digitFillTransform = DaniDojoAssetUtility.CreateImage("CurReqBarValueFill" + i, Path.Combine(baseNumberPath, "NoBorder", "0.png"), numLocation, panel.transform).transform;
+                //    }
+                //    if (digitTransparentTransform == null)
+                //    {
+                //        digitTransparentTransform = DaniDojoAssetUtility.CreateImage("CurReqBarValueTransparent" + i, Path.Combine(baseNumberPath, "Transparent", "0.png"), numLocation, panel.transform).transform;
+                //    }
 
-                    GameObject digitBorder = digitBorderTransform.gameObject;
-                    GameObject digitFill = digitFillTransform.gameObject;
-                    GameObject digitTransparent = digitTransparentTransform.gameObject;
+                //    GameObject digitBorder = digitBorderTransform.gameObject;
+                //    GameObject digitFill = digitFillTransform.gameObject;
+                //    GameObject digitTransparent = digitTransparentTransform.gameObject;
 
-                    if (i < num.Length)
-                    {
-                        int numValue = int.Parse(num[i].ToString());
-                        if (DigitBigBorder.Count > numValue)
-                        {
-                            DaniDojoAssetUtility.ChangeImageSprite(digitBorder, DigitBigBorder[numValue]);
-                        }
-                        if (DigitBigFill.Count > numValue)
-                        {
-                            DaniDojoAssetUtility.ChangeImageSprite(digitFill, DigitBigFill[numValue]);
-                        }
-                        if (DigitBigTransparent.Count > numValue)
-                        {
-                            DaniDojoAssetUtility.ChangeImageSprite(digitTransparent, DigitBigTransparent[numValue]);
-                        }
+                //    if (i < num.Length)
+                //    {
+                //        int numValue = int.Parse(num[i].ToString());
+                //        if (DigitBigBorder.Count > numValue)
+                //        {
+                //            DaniDojoAssetUtility.ChangeImageSprite(digitBorder, DigitBigBorder[numValue]);
+                //        }
+                //        if (DigitBigFill.Count > numValue)
+                //        {
+                //            DaniDojoAssetUtility.ChangeImageSprite(digitFill, DigitBigFill[numValue]);
+                //        }
+                //        if (DigitBigTransparent.Count > numValue)
+                //        {
+                //            DaniDojoAssetUtility.ChangeImageSprite(digitTransparent, DigitBigTransparent[numValue]);
+                //        }
 
-                        var digitBorderImage = digitBorder.GetComponent<Image>();
-                        var digitFillImage = digitFill.GetComponent<Image>();
-                        var digitTransparentImage = digitTransparent.GetComponent<Image>();
+                //        var digitBorderImage = digitBorder.GetComponent<Image>();
+                //        var digitFillImage = digitFill.GetComponent<Image>();
+                //        var digitTransparentImage = digitTransparent.GetComponent<Image>();
 
-                        if (digitBorderImage != null)
-                        {
-                            if (isGold)
-                            {
-                                digitBorderImage.color = GoldReqTextBorderColor;
-                            }
-                            else if (num == "0")
-                            {
-                                digitBorderImage.color = ZeroTextBorderColor;
-                            }
-                            else
-                            {
-                                digitBorderImage.color = NormalTextBorderColor;
-                            }
-                        }
-                        if (digitFillImage != null)
-                        {
-                            if (isGold)
-                            {
-                                digitFillImage.color = GoldReqTextFillColor;
-                            }
-                            else if (num == "0")
-                            {
-                                digitFillImage.color = ZeroTextFillColor;
-                            }
-                            else
-                            {
-                                digitFillImage.color = NormalTextFillColor;
-                            }
-                        }
-                        if (digitTransparentImage != null)
-                        {
-                            if (isGold)
-                            {
-                                digitTransparentImage.color = GoldReqTextTransparentColor;
-                            }
-                            else if (num == "0")
-                            {
-                                digitTransparentImage.color = ZeroTextTransparentColor;
-                            }
-                            else
-                            {
-                                digitTransparentImage.color = NormalTextTransparentColor;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        var digitBorderImage = digitBorder.GetComponent<Image>();
-                        var digitFillImage = digitFill.GetComponent<Image>();
-                        var digitTransparentImage = digitTransparent.GetComponent<Image>();
-                        if (digitBorderImage != null)
-                        {
-                            digitBorderImage.color = InvisibleColor;
-                        }
-                        if (digitFillImage != null)
-                        {
-                            digitFillImage.color = InvisibleColor;
-                        }
-                        if (digitTransparentImage != null)
-                        {
-                            digitTransparentImage.color = InvisibleColor;
-                        }
-                    }
+                //        if (digitBorderImage != null)
+                //        {
+                //            if (isGold)
+                //            {
+                //                digitBorderImage.color = GoldReqTextBorderColor;
+                //            }
+                //            else if (num == "0")
+                //            {
+                //                digitBorderImage.color = ZeroTextBorderColor;
+                //            }
+                //            else
+                //            {
+                //                digitBorderImage.color = NormalTextBorderColor;
+                //            }
+                //        }
+                //        if (digitFillImage != null)
+                //        {
+                //            if (isGold)
+                //            {
+                //                digitFillImage.color = GoldReqTextFillColor;
+                //            }
+                //            else if (num == "0")
+                //            {
+                //                digitFillImage.color = ZeroTextFillColor;
+                //            }
+                //            else
+                //            {
+                //                digitFillImage.color = NormalTextFillColor;
+                //            }
+                //        }
+                //        if (digitTransparentImage != null)
+                //        {
+                //            if (isGold)
+                //            {
+                //                digitTransparentImage.color = GoldReqTextTransparentColor;
+                //            }
+                //            else if (num == "0")
+                //            {
+                //                digitTransparentImage.color = ZeroTextTransparentColor;
+                //            }
+                //            else
+                //            {
+                //                digitTransparentImage.color = NormalTextTransparentColor;
+                //            }
+                //        }
+                //    }
+                //    else
+                //    {
+                //        var digitBorderImage = digitBorder.GetComponent<Image>();
+                //        var digitFillImage = digitFill.GetComponent<Image>();
+                //        var digitTransparentImage = digitTransparent.GetComponent<Image>();
+                //        if (digitBorderImage != null)
+                //        {
+                //            digitBorderImage.color = InvisibleColor;
+                //        }
+                //        if (digitFillImage != null)
+                //        {
+                //            digitFillImage.color = InvisibleColor;
+                //        }
+                //        if (digitTransparentImage != null)
+                //        {
+                //            digitTransparentImage.color = InvisibleColor;
+                //        }
+                //    }
 
-                }
+                //}
             }
 
-            static void InitializeDigitSpriteLists()
-            {
-                //Plugin.Log.LogInfo("Initialize DigitBigBorder");
+            //static void InitializeDigitSpriteLists()
+            //{
+            //    //Plugin.Log.LogInfo("Initialize DigitBigBorder");
 
-                if (DigitBigBorder == null)
-                {
-                    DigitBigBorder = new List<Sprite>();
-                }
-                if (DigitBigBorder == null || DigitBigBorder.Count != 10)
-                {
-                    DigitBigBorder.Clear();
-                    DigitBigBorder = new List<Sprite>();
-                    for (int i = 0; i < 10; i++)
-                    {
-                        DigitBigBorder.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine(BaseImageFilePath, "Digits", "Big", "Border", i.ToString() + ".png")));
-                    }
-                }
-                //Plugin.Log.LogInfo("Initialize DigitBigFill");
-                if (DigitBigFill == null)
-                {
-                    DigitBigFill = new List<Sprite>();
-                }
-                if (DigitBigFill == null || DigitBigFill.Count != 10)
-                {
-                    DigitBigFill.Clear();
-                    DigitBigFill = new List<Sprite>();
-                    for (int i = 0; i < 10; i++)
-                    {
-                        DigitBigFill.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine(BaseImageFilePath, "Digits", "Big", "NoBorder", i.ToString() + ".png")));
-                    }
-                }
-                //Plugin.Log.LogInfo("Initialize DigitBigTransparent");
-                if (DigitBigTransparent == null)
-                {
-                    DigitBigTransparent = new List<Sprite>();
-                }
-                if (DigitBigTransparent == null || DigitBigTransparent.Count != 10)
-                {
-                    DigitBigTransparent.Clear();
-                    DigitBigTransparent = new List<Sprite>();
-                    for (int i = 0; i < 10; i++)
-                    {
-                        DigitBigTransparent.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine(BaseImageFilePath, "Digits", "Big", "Transparent", i.ToString() + ".png")));
-                    }
-                }
+            //    if (DigitBigBorder == null)
+            //    {
+            //        DigitBigBorder = new List<Sprite>();
+            //    }
+            //    if (DigitBigBorder == null || DigitBigBorder.Count != 10)
+            //    {
+            //        DigitBigBorder.Clear();
+            //        DigitBigBorder = new List<Sprite>();
+            //        for (int i = 0; i < 10; i++)
+            //        {
+            //            DigitBigBorder.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine("Digits", "Big", "Border", i.ToString() + ".png")));
+            //        }
+            //    }
+            //    //Plugin.Log.LogInfo("Initialize DigitBigFill");
+            //    if (DigitBigFill == null)
+            //    {
+            //        DigitBigFill = new List<Sprite>();
+            //    }
+            //    if (DigitBigFill == null || DigitBigFill.Count != 10)
+            //    {
+            //        DigitBigFill.Clear();
+            //        DigitBigFill = new List<Sprite>();
+            //        for (int i = 0; i < 10; i++)
+            //        {
+            //            DigitBigFill.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine("Digits", "Big", "NoBorder", i.ToString() + ".png")));
+            //        }
+            //    }
+            //    //Plugin.Log.LogInfo("Initialize DigitBigTransparent");
+            //    if (DigitBigTransparent == null)
+            //    {
+            //        DigitBigTransparent = new List<Sprite>();
+            //    }
+            //    if (DigitBigTransparent == null || DigitBigTransparent.Count != 10)
+            //    {
+            //        DigitBigTransparent.Clear();
+            //        DigitBigTransparent = new List<Sprite>();
+            //        for (int i = 0; i < 10; i++)
+            //        {
+            //            DigitBigTransparent.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine("Digits", "Big", "Transparent", i.ToString() + ".png")));
+            //        }
+            //    }
 
-                //Plugin.Log.LogInfo("Initialize DigitSmallBorder");
-                if (DigitSmallBorder == null)
-                {
-                    DigitSmallBorder = new List<Sprite>();
-                }
-                if (DigitSmallBorder == null || DigitSmallBorder.Count != 10)
-                {
-                    DigitSmallBorder.Clear();
-                    DigitSmallBorder = new List<Sprite>();
-                    for (int i = 0; i < 10; i++)
-                    {
-                        DigitSmallBorder.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine(BaseImageFilePath, "Digits", "Small", "Border", i.ToString() + ".png")));
-                    }
-                }
-                //Plugin.Log.LogInfo("Initialize DigitSmallFill");
-                if (DigitSmallFill == null)
-                {
-                    DigitSmallFill = new List<Sprite>();
-                }
-                if (DigitSmallFill == null || DigitSmallFill.Count != 10)
-                {
-                    DigitSmallFill.Clear();
-                    DigitSmallFill = new List<Sprite>();
-                    for (int i = 0; i < 10; i++)
-                    {
-                        DigitSmallFill.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine(BaseImageFilePath, "Digits", "Small", "NoBorder", i.ToString() + ".png")));
-                    }
-                }
-                //Plugin.Log.LogInfo("Initialize DigitSmallTransparent");
-                if (DigitSmallTransparent == null)
-                {
-                    DigitSmallTransparent = new List<Sprite>();
-                }
-                if (DigitSmallTransparent == null || DigitSmallTransparent.Count != 10)
-                {
-                    DigitSmallTransparent.Clear();
-                    DigitSmallTransparent = new List<Sprite>();
-                    for (int i = 0; i < 10; i++)
-                    {
-                        DigitSmallTransparent.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine(BaseImageFilePath, "Digits", "Small", "Transparent", i.ToString() + ".png")));
-                    }
-                }
-                //Plugin.Log.LogInfo("Initialize Digits Finish");
-            }
+            //    //Plugin.Log.LogInfo("Initialize DigitSmallBorder");
+            //    if (DigitSmallBorder == null)
+            //    {
+            //        DigitSmallBorder = new List<Sprite>();
+            //    }
+            //    if (DigitSmallBorder == null || DigitSmallBorder.Count != 10)
+            //    {
+            //        DigitSmallBorder.Clear();
+            //        DigitSmallBorder = new List<Sprite>();
+            //        for (int i = 0; i < 10; i++)
+            //        {
+            //            DigitSmallBorder.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine("Digits", "Small", "Border", i.ToString() + ".png")));
+            //        }
+            //    }
+            //    //Plugin.Log.LogInfo("Initialize DigitSmallFill");
+            //    if (DigitSmallFill == null)
+            //    {
+            //        DigitSmallFill = new List<Sprite>();
+            //    }
+            //    if (DigitSmallFill == null || DigitSmallFill.Count != 10)
+            //    {
+            //        DigitSmallFill.Clear();
+            //        DigitSmallFill = new List<Sprite>();
+            //        for (int i = 0; i < 10; i++)
+            //        {
+            //            DigitSmallFill.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine("Digits", "Small", "NoBorder", i.ToString() + ".png")));
+            //        }
+            //    }
+            //    //Plugin.Log.LogInfo("Initialize DigitSmallTransparent");
+            //    if (DigitSmallTransparent == null)
+            //    {
+            //        DigitSmallTransparent = new List<Sprite>();
+            //    }
+            //    if (DigitSmallTransparent == null || DigitSmallTransparent.Count != 10)
+            //    {
+            //        DigitSmallTransparent.Clear();
+            //        DigitSmallTransparent = new List<Sprite>();
+            //        for (int i = 0; i < 10; i++)
+            //        {
+            //            DigitSmallTransparent.Add(DaniDojoAssetUtility.CreateSprite(Path.Combine("Digits", "Small", "Transparent", i.ToString() + ".png")));
+            //        }
+            //    }
+            //    //Plugin.Log.LogInfo("Initialize Digits Finish");
+            //}
         }
 
         public static class SelectAssets
         {
             // This will be the name of the image file
-            enum SelectAssetName
-            {
-                CourseBorderLeftBlue,
-                CourseBorderLeftGaiden,
-                CourseBorderLeftGold,
-                CourseBorderLeftKyuu,
-                CourseBorderLeftRed,
-                CourseBorderLeftSilver,
-                CourseBorderRightBlue,
-                CourseBorderRightGaiden,
-                CourseBorderRightGold,
-                CourseBorderRightKyuu,
-                CourseBorderRightRed,
-                CourseBorderRightSilver,
-                CourseEasy,
-                CourseHard,
-                CourseNormal,
-                CourseOni,
-                CourseUra,
-                Star1,
-                Star2,
-                Star3,
-                Star4,
-                Star5,
-                Star6,
-                Star7,
-                Star8,
-                Star9,
-                Star10,
-                Star10Plus,
-                BigGoldClear,
-                BigGoldDFC,
-                BigGoldFC,
-                BigRedClear,
-                BigRedDFC,
-                BigRedFC,
-                SmallGoldClear,
-                SmallGoldDFC,
-                SmallGoldFC,
-                SmallRedClear,
-                SmallRedDFC,
-                SmallRedFC,
-                Top1dan,
-                Top1kyuu,
-                Top2dan,
-                Top2kyuu,
-                Top3dan,
-                Top3kyuu,
-                Top4dan,
-                Top4kyuu,
-                Top5dan,
-                Top5kyuu,
-                Top6dan,
-                Top7dan,
-                Top8dan,
-                Top9dan,
-                Top10dan,
-                TopBlueBg,
-                TopChojin,
-                TopGaiden,
-                TopGoldBg,
-                TopKuroto,
-                TopKyuuBg,
-                TopMeijin,
-                TopOriginalBg,
-                TopRedBg,
-                TopSelectedDan,
-                TopSilverBg,
-                TopTatsujin,
-                ArrowLeft,
-                ArrowRight,
-                BgLightsOff,
-                BgLightsOn,
-                CourseBg,
-                PersonalBestBg,
-                ReqSongIndicator1,
-                ReqSongIndicator2,
-                ReqSongIndicator3,
-                ReqSongIndicatorTotal,
-                RequirementsEachPanel,
-                RequirementsMainPanel,
-                RequirementsPanelBorder,
-                SongIndicator1,
-                SongIndicator2,
-                SongIndicator3,
-                SongTitleBg,
-                SoulGaugeReqPanel,
-                BlueBg,
-                chojin,
-                dan1,
-                dan2,
-                dan3,
-                dan4,
-                dan5,
-                dan6,
-                dan7,
-                dan8,
-                dan9,
-                dan10,
-                gaiden,
-                GoldBg,
-                kuroto,
-                kyuu1,
-                kyuu2,
-                kyuu3,
-                kyuu4,
-                kyuu5,
-                meijin,
-                original,
-                RedBg,
-                SilverBg,
-                TanBg,
-                tatsujin,
-                WoodBg,
-            }
+            //enum SelectAssetName
+            //{
+            //    CourseBorderLeftBlue,
+            //    CourseBorderLeftGaiden,
+            //    CourseBorderLeftGold,
+            //    CourseBorderLeftKyuu,
+            //    CourseBorderLeftRed,
+            //    CourseBorderLeftSilver,
+            //    CourseBorderRightBlue,
+            //    CourseBorderRightGaiden,
+            //    CourseBorderRightGold,
+            //    CourseBorderRightKyuu,
+            //    CourseBorderRightRed,
+            //    CourseBorderRightSilver,
+            //    CourseEasy,
+            //    CourseHard,
+            //    CourseNormal,
+            //    CourseOni,
+            //    CourseUra,
+            //    Star1,
+            //    Star2,
+            //    Star3,
+            //    Star4,
+            //    Star5,
+            //    Star6,
+            //    Star7,
+            //    Star8,
+            //    Star9,
+            //    Star10,
+            //    Star10Plus,
+            //    BigGoldClear,
+            //    BigGoldDFC,
+            //    BigGoldFC,
+            //    BigRedClear,
+            //    BigRedDFC,
+            //    BigRedFC,
+            //    SmallGoldClear,
+            //    SmallGoldDFC,
+            //    SmallGoldFC,
+            //    SmallRedClear,
+            //    SmallRedDFC,
+            //    SmallRedFC,
+            //    Top1dan,
+            //    Top1kyuu,
+            //    Top2dan,
+            //    Top2kyuu,
+            //    Top3dan,
+            //    Top3kyuu,
+            //    Top4dan,
+            //    Top4kyuu,
+            //    Top5dan,
+            //    Top5kyuu,
+            //    Top6dan,
+            //    Top7dan,
+            //    Top8dan,
+            //    Top9dan,
+            //    Top10dan,
+            //    TopBlueBg,
+            //    TopChojin,
+            //    TopGaiden,
+            //    TopGoldBg,
+            //    TopKuroto,
+            //    TopKyuuBg,
+            //    TopMeijin,
+            //    TopOriginalBg,
+            //    TopRedBg,
+            //    TopSelectedDan,
+            //    TopSilverBg,
+            //    TopTatsujin,
+            //    ArrowLeft,
+            //    ArrowRight,
+            //    BgLightsOff,
+            //    BgLightsOn,
+            //    CourseBg,
+            //    PersonalBestBg,
+            //    ReqSongIndicator1,
+            //    ReqSongIndicator2,
+            //    ReqSongIndicator3,
+            //    ReqSongIndicatorTotal,
+            //    RequirementsEachPanel,
+            //    RequirementsMainPanel,
+            //    RequirementsPanelBorder,
+            //    SongIndicator1,
+            //    SongIndicator2,
+            //    SongIndicator3,
+            //    SongTitleBg,
+            //    SoulGaugeReqPanel,
+            //    BlueBg,
+            //    chojin,
+            //    dan1,
+            //    dan2,
+            //    dan3,
+            //    dan4,
+            //    dan5,
+            //    dan6,
+            //    dan7,
+            //    dan8,
+            //    dan9,
+            //    dan10,
+            //    gaiden,
+            //    GoldBg,
+            //    kuroto,
+            //    kyuu1,
+            //    kyuu2,
+            //    kyuu3,
+            //    kyuu4,
+            //    kyuu5,
+            //    meijin,
+            //    original,
+            //    RedBg,
+            //    SilverBg,
+            //    TanBg,
+            //    tatsujin,
+            //    WoodBg,
+            //}
 
-            static Dictionary<SelectAssetName, Sprite> SelectAssetSprites;
+            //static Dictionary<SelectAssetName, Sprite> SelectAssetSprites;
 
             public static void InitializeSceneAssets(GameObject parent)
             {
@@ -770,65 +932,69 @@ namespace DaniDojo.Patches
                 daniDojoCanvasScaler.screenMatchMode = CanvasScaler.ScreenMatchMode.Expand;
                 daniDojoCanvasScaler.matchWidthOrHeight = 0;
 
-                DaniDojoAssetUtility.CreateImage("BgLightsOn", Path.Combine(BaseImageFilePath, "Select", "BgLightsOn.png"), new Vector2(0, 0), parent.transform);
+                //DaniDojoAssetUtility.CreateImage("BgLightsOff", Path.Combine("Select", "BgLightsOff.png"), new Vector2(0, 0), parent.transform);
+                //DaniDojoAssetUtility.CreateImage("BgLightsOn", Path.Combine("Select", "BgLightsOn.png"), new Vector2(0, 0), parent.transform);
+                AssetUtility.CreateImageChild(parent, "BgLightsOff", Vector2.zero, Path.Combine("Select", "BgLightsOff.png"));
+                AssetUtility.CreateImageChild(parent, "BgLightsOn", Vector2.zero, Path.Combine("Select", "BgLightsOn.png"));
+                // TODO: Make a coroutine to flicker the BgLightsOn's transparency
 
-                InitializeSelectAssetSprites();
+                //InitializeSelectAssetSprites();
             }
 
-            private static void InitializeSelectAssetSprites()
-            {
-                if (SelectAssetSprites == null)
-                {
-                    SelectAssetSprites = new Dictionary<SelectAssetName, Sprite>();
-                }
-                foreach (SelectAssetName asset in Enum.GetValues(typeof(SelectAssetName)))
-                {
-                    InitializeSelectAssetSprite(asset);
-                }
-            }
+            //private static void InitializeSelectAssetSprites()
+            //{
+            //    if (SelectAssetSprites == null)
+            //    {
+            //        SelectAssetSprites = new Dictionary<SelectAssetName, Sprite>();
+            //    }
+            //    foreach (SelectAssetName asset in Enum.GetValues(typeof(SelectAssetName)))
+            //    {
+            //        InitializeSelectAssetSprite(asset);
+            //    }
+            //}
 
-            private static void InitializeSelectAssetSprite(SelectAssetName asset)
-            {
-                if (!SelectAssetSprites.ContainsKey(asset))
-                {
-                    DirectoryInfo dirInfo = new DirectoryInfo(Path.Combine(BaseImageFilePath));
-                    if (dirInfo.Exists)
-                    {
-                        var assetFile = dirInfo.GetFiles(asset.ToString() + ".png", SearchOption.AllDirectories);
-                        if (assetFile.Length > 0)
-                        {
-                            if (assetFile.Length > 1)
-                            {
-                                Plugin.Log.LogInfo("Multiple files for " + asset.ToString() + " found, loading the first one found!");
+            //private static void InitializeSelectAssetSprite(SelectAssetName asset)
+            //{
+            //    if (!SelectAssetSprites.ContainsKey(asset))
+            //    {
+            //        DirectoryInfo dirInfo = new DirectoryInfo(Path.Combine(BaseImageFilePath));
+            //        if (dirInfo.Exists)
+            //        {
+            //            var assetFile = dirInfo.GetFiles(asset.ToString() + ".png", SearchOption.AllDirectories);
+            //            if (assetFile.Length > 0)
+            //            {
+            //                if (assetFile.Length > 1)
+            //                {
+            //                    Plugin.Log.LogInfo("Multiple files for " + asset.ToString() + " found, loading the first one found!");
 
-                            }
-                            var sprite = DaniDojoAssetUtility.CreateSprite(assetFile[0].FullName);
-                            SelectAssetSprites.Add(asset, sprite);
-                        }
-                        else
-                        {
-                            Plugin.Log.LogError(asset.ToString() + ".png not found!");
-                        }
-                    }
-                    else
-                    {
-                        Plugin.Log.LogError("DaniDojoAsset file path not found!");
-                    }
-                }
-            }
+            //                }
+            //                var sprite = DaniDojoAssetUtility.CreateSprite(assetFile[0].FullName);
+            //                SelectAssetSprites.Add(asset, sprite);
+            //            }
+            //            else
+            //            {
+            //                Plugin.Log.LogError(asset.ToString() + ".png not found!");
+            //            }
+            //        }
+            //        else
+            //        {
+            //            Plugin.Log.LogError("DaniDojoAsset file path not found!");
+            //        }
+            //    }
+            //}
 
-            private static Sprite GetAssetSprite(SelectAssetName asset)
-            {
-                InitializeSelectAssetSprite(asset);
-                if (SelectAssetSprites.ContainsKey(asset))
-                {
-                    return SelectAssetSprites[asset];
-                }
-                else
-                {
-                    return DaniDojoAssetUtility.CreateSprite("");
-                }
-            }
+            //private static Sprite GetAssetSprite(SelectAssetName asset)
+            //{
+            //    InitializeSelectAssetSprite(asset);
+            //    if (SelectAssetSprites.ContainsKey(asset))
+            //    {
+            //        return SelectAssetSprites[asset];
+            //    }
+            //    else
+            //    {
+            //        return DaniDojoAssetUtility.CreateSprite("");
+            //    }
+            //}
 
             /// <summary>
             /// 
@@ -869,101 +1035,188 @@ namespace DaniDojo.Patches
                 {
                     var highScore = SaveDataManager.GetCourseRecord(seriesInfo.Courses[i].Hash);
 
-                    SelectAssetName backgroundName;
+                    string backgroundName;
                     switch (seriesInfo.Courses[i].Background)
                     {
                         case CourseBackground.Tan:
-                            backgroundName = SelectAssetName.TopOriginalBg;
+                            backgroundName = "Tan.png";
                             break;
                         case CourseBackground.Wood:
-                            backgroundName = SelectAssetName.TopKyuuBg;
+                            backgroundName = "Wood.png";
                             break;
                         case CourseBackground.Blue:
-                            backgroundName = SelectAssetName.TopBlueBg;
+                            backgroundName = "Blue.png";
                             break;
                         case CourseBackground.Red:
-                            backgroundName = SelectAssetName.TopRedBg;
+                            backgroundName = "Red.png";
                             break;
                         case CourseBackground.Silver:
-                            backgroundName = SelectAssetName.TopSilverBg;
+                            backgroundName = "Silver.png";
                             break;
                         case CourseBackground.Gold:
-                            backgroundName = SelectAssetName.TopGoldBg;
+                            backgroundName = "Gold.png";
+                            break;
+                        case CourseBackground.Gaiden:
+                            backgroundName = "Gaiden.png";
                             break;
                         default:
-                            backgroundName = SelectAssetName.TopOriginalBg;
+                            // This would ideally be Sousaku, but I don't have assets for that
+                            backgroundName = "Gaiden.png";
                             break;
                     }
-                    string courseId = seriesInfo.Courses[i].Id;
-                    if (int.TryParse(courseId, out int _))
+                    string topText;
+                    string botText = "";
+
+                    switch (seriesInfo.Courses[i].CourseLevel)
                     {
-                        courseId = seriesInfo.Courses[i].Title;
+                        case DaniCourseLevel.kyuuFirst:
+                        case DaniCourseLevel.dan1:
+                            topText = "Starting.png";
+                            break;
+                        case DaniCourseLevel.kyuu10:
+                        case DaniCourseLevel.dan10:
+                            topText = "10th.png";
+                            break;
+                        case DaniCourseLevel.kyuu9:
+                        case DaniCourseLevel.dan9:
+                            topText = "9th.png";
+                            break;
+                        case DaniCourseLevel.kyuu8:
+                        case DaniCourseLevel.dan8:
+                            topText = "8th.png";
+                            break;
+                        case DaniCourseLevel.kyuu7:
+                        case DaniCourseLevel.dan7:
+                            topText = "7th.png";
+                            break;
+                        case DaniCourseLevel.kyuu6:
+                        case DaniCourseLevel.dan6:
+                            topText = "6th.png";
+                            break;
+                        case DaniCourseLevel.kyuu5:
+                        case DaniCourseLevel.dan5:
+                            topText = "5th.png";
+                            break;
+                        case DaniCourseLevel.kyuu4:
+                        case DaniCourseLevel.dan4:
+                            topText = "4th.png";
+                            break;
+                        case DaniCourseLevel.kyuu3:
+                        case DaniCourseLevel.dan3:
+                            topText = "3rd.png";
+                            break;
+                        case DaniCourseLevel.kyuu2:
+                        case DaniCourseLevel.dan2:
+                            topText = "2nd.png";
+                            break;
+                        case DaniCourseLevel.kyuu1:
+                            topText = "1st.png";
+                            break;
+                        case DaniCourseLevel.kuroto:
+                            topText = "kuro.png";
+                            break;
+                        case DaniCourseLevel.meijin:
+                            topText = "mei.png";
+                            break;
+                        case DaniCourseLevel.chojin:
+                            topText = "cho.png";
+                            break;
+                        case DaniCourseLevel.tatsujin:
+                            topText = "tatsu.png";
+                            break;
+                        case DaniCourseLevel.gaiden:
+                            topText = "gai.png";
+                            botText = "den.png";
+                            break;
+                        default:
+                            // Would be sou saku if I had the assets
+                            //topText = "sou.png";
+                            //botText = "saku.png";
+                            topText = "gai.png";
+                            botText = "den.png";
+                            break;
                     }
-                    var textName = courseId switch
+
+                    switch (seriesInfo.Courses[i].CourseLevel)
                     {
-                        "5kyuu" or "五級 5th Kyu" => SelectAssetName.Top5kyuu,
-                        "4kyuu" or "四級 4th Kyu" => SelectAssetName.Top4kyuu,
-                        "3kyuu" or "三級 3rd Kyu" => SelectAssetName.Top3kyuu,
-                        "2kyuu" or "二級 2nd Kyu" => SelectAssetName.Top2kyuu,
-                        "1kyuu" or "一級 1st Kyu" => SelectAssetName.Top1kyuu,
-                        "1dan" or "初段 1st Dan" => SelectAssetName.Top1dan,
-                        "2dan" or "二段 2nd Dan" => SelectAssetName.Top2dan,
-                        "3dan" or "三段 3rd Dan" => SelectAssetName.Top3dan,
-                        "4dan" or "四段 4th Dan" => SelectAssetName.Top4dan,
-                        "5dan" or "五段 5th Dan" => SelectAssetName.Top5dan,
-                        "6dan" or "六段 6th Dan" => SelectAssetName.Top6dan,
-                        "7dan" or "七段 7th Dan" => SelectAssetName.Top7dan,
-                        "8dan" or "八段 8th Dan" => SelectAssetName.Top8dan,
-                        "9dan" or "九段 9th Dan" => SelectAssetName.Top9dan,
-                        "10dan" or "十段 10th Dan" => SelectAssetName.Top10dan,
-                        "11dan" or "玄人 Kuroto" => SelectAssetName.TopKuroto,
-                        "12dan" or "名人 Meijin" => SelectAssetName.TopMeijin,
-                        "13dan" or "超人 Chojin" => SelectAssetName.TopChojin,
-                        "14dan" or "達人 Tatsujin" => SelectAssetName.TopTatsujin,
-                        _ => SelectAssetName.TopGaiden,
-                    };
+                        case DaniCourseLevel.kyuuFirst:
+                        case DaniCourseLevel.kyuu10:
+                        case DaniCourseLevel.kyuu9:
+                        case DaniCourseLevel.kyuu8:
+                        case DaniCourseLevel.kyuu7:
+                        case DaniCourseLevel.kyuu6:
+                        case DaniCourseLevel.kyuu5:
+                        case DaniCourseLevel.kyuu4:
+                        case DaniCourseLevel.kyuu3:
+                        case DaniCourseLevel.kyuu2:
+                        case DaniCourseLevel.kyuu1:
+                            botText = "kyuu.png";
+                            break;
+                        case DaniCourseLevel.dan1:
+                        case DaniCourseLevel.dan2:
+                        case DaniCourseLevel.dan3:
+                        case DaniCourseLevel.dan4:
+                        case DaniCourseLevel.dan5:
+                        case DaniCourseLevel.dan6:
+                        case DaniCourseLevel.dan7:
+                        case DaniCourseLevel.dan8:
+                        case DaniCourseLevel.dan9:
+                        case DaniCourseLevel.dan10:
+                            botText = "dan.png";
+                            break;
+                        case DaniCourseLevel.kuroto:
+                        case DaniCourseLevel.meijin:
+                        case DaniCourseLevel.chojin:
+                        case DaniCourseLevel.tatsujin:
+                            botText = "jin.png";
+                            break;
+                    }
                     GameObject topCourseObject = new GameObject(seriesInfo.Courses[i].Title);
                     topCourseObject.transform.SetParent(topCoursesParent.transform);
                     topCourseObject.transform.position = new Vector2(183 + (68 * i), 884);
-                    DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Background", GetAssetSprite(backgroundName), new Vector2(0, 0), topCourseObject.transform);
-                    DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Text", GetAssetSprite(textName), new Vector2(19, 24), topCourseObject.transform);
+                    AssetUtility.CreateImageChild(topCourseObject, seriesInfo.Courses[i].Title + "Background", Vector2.zero, Path.Combine("Course", "Top", "Bg", backgroundName));
+                    AssetUtility.CreateImageChild(topCourseObject, seriesInfo.Courses[i].Title + "TopText", new Vector2(19, 62), Path.Combine("Course", "Top", "Text", topText));
+                    AssetUtility.CreateImageChild(topCourseObject, seriesInfo.Courses[i].Title + "BotText", new Vector2(19, 24), Path.Combine("Course", "Top", "Text", botText));
+                    //DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Background", GetAssetSprite(backgroundName), new Vector2(0, 0), topCourseObject.transform);
+                    //DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Text", GetAssetSprite(textName), new Vector2(19, 24), topCourseObject.transform);
 
                     bool skip = false;
-                    SelectAssetName recordName = SelectAssetName.CourseNormal;
+                    string recordName = string.Empty;
                     if (highScore.RankCombo.Rank == DaniRank.GoldClear)
                     {
                         if (highScore.RankCombo.Combo == DaniCombo.Rainbow)
                         {
-                            recordName = SelectAssetName.SmallGoldDFC;
+                            recordName = "SmallGoldDFC.png";
                         }
                         else if (highScore.RankCombo.Combo == DaniCombo.Gold)
                         {
-                            recordName = SelectAssetName.SmallGoldFC;
+                            recordName = "SmallGoldFC.png";
                         }
                         else if (highScore.RankCombo.Combo == DaniCombo.Silver)
                         {
-                            recordName = SelectAssetName.SmallGoldClear;
+                            recordName = "SmallGoldClear.png";
                         }
                     }
                     else if (highScore.RankCombo.Rank == DaniRank.RedClear)
                     {
                         if (highScore.RankCombo.Combo == DaniCombo.Rainbow)
                         {
-                            recordName = SelectAssetName.SmallRedDFC;
+                            recordName = "SmallRedDFC.png";
                         }
                         else if (highScore.RankCombo.Combo == DaniCombo.Gold)
                         {
-                            recordName = SelectAssetName.SmallRedFC;
+                            recordName = "SmallRedFC.png";
                         }
                         else if (highScore.RankCombo.Combo == DaniCombo.Silver)
                         {
-                            recordName = SelectAssetName.SmallRedClear;
+                            recordName = "SmallRedClear.png";
                         }
                     }
 
-                    if (recordName != SelectAssetName.CourseNormal)
+                    if (recordName != string.Empty)
                     {
-                        DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Record", GetAssetSprite(recordName), new Vector2(0, 98), topCourseObject.transform);
+                        AssetUtility.CreateImageChild(topCourseObject, seriesInfo.Courses[i].Title + "Record", new Vector2(0, 98), Path.Combine("Select", "ResultIcons", "Small", recordName));
+                        //DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Record", GetAssetSprite(recordName), new Vector2(0, 98), topCourseObject.transform);
                     }
                 }
             }
@@ -1004,46 +1257,62 @@ namespace DaniDojo.Patches
                         break;
                 }
 
-                var courseObject = DaniDojoAssetUtility.CreateImage("CourseBg" + courseBgNum++, GetAssetSprite(SelectAssetName.CourseBg), CourseBgLocation, parent.transform);
+                var courseObject = AssetUtility.CreateImageChild(parent, "CourseBg" + courseBgNum++, CourseBgLocation, Path.Combine("Select", "CourseBg.png"));
+                //var courseObject = DaniDojoAssetUtility.CreateImage("CourseBg" + courseBgNum++, GetAssetSprite(SelectAssetName.CourseBg), CourseBgLocation, parent.transform);
 
-                SelectAssetName leftBorderName;
-                SelectAssetName rightBorderName;
-                var background = courseInfo.Background;
-
-                switch (background)
+                string borderFileName = string.Empty;
+                borderFileName = courseInfo.Background switch
                 {
-                    case CourseBackground.None:
-                    case CourseBackground.Tan:
-                        leftBorderName = SelectAssetName.CourseBorderLeftGaiden;
-                        rightBorderName = SelectAssetName.CourseBorderRightGaiden;
-                        break;
-                    case CourseBackground.Wood:
-                        leftBorderName = SelectAssetName.CourseBorderLeftKyuu;
-                        rightBorderName = SelectAssetName.CourseBorderRightKyuu;
-                        break;
-                    case CourseBackground.Blue:
-                        leftBorderName = SelectAssetName.CourseBorderLeftBlue;
-                        rightBorderName = SelectAssetName.CourseBorderRightBlue;
-                        break;
-                    case CourseBackground.Red:
-                        leftBorderName = SelectAssetName.CourseBorderLeftRed;
-                        rightBorderName = SelectAssetName.CourseBorderRightRed;
-                        break;
-                    case CourseBackground.Silver:
-                        leftBorderName = SelectAssetName.CourseBorderLeftSilver;
-                        rightBorderName = SelectAssetName.CourseBorderRightSilver;
-                        break;
-                    case CourseBackground.Gold:
-                        leftBorderName = SelectAssetName.CourseBorderLeftGold;
-                        rightBorderName = SelectAssetName.CourseBorderRightGold;
-                        break;
-                    default:
-                        leftBorderName = SelectAssetName.CourseBorderLeftGaiden;
-                        rightBorderName = SelectAssetName.CourseBorderRightGaiden;
-                        break;
-                }
-                DaniDojoAssetUtility.CreateImage("LeftBorder", GetAssetSprite(leftBorderName), new Vector2(22, 33), courseObject.transform);
-                DaniDojoAssetUtility.CreateImage("RightBorder", GetAssetSprite(rightBorderName), new Vector2(1458, 33), courseObject.transform);
+                    CourseBackground.Tan => "Tan.png",
+                    CourseBackground.Wood => "Wood.png",
+                    CourseBackground.Blue => "Blue.png",
+                    CourseBackground.Red => "Red.png",
+                    CourseBackground.Silver => "Silver.png",
+                    CourseBackground.Gold => "Gold.png",
+                    CourseBackground.Gaiden => "Gaiden.png",
+                    _ => "Sousaku.png",
+                };
+
+                //SelectAssetName leftBorderName;
+                //SelectAssetName rightBorderName;
+                //var background = courseInfo.Background;
+
+                //switch (background)
+                //{
+                //    case CourseBackground.None:
+                //    case CourseBackground.Tan:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftGaiden;
+                //        rightBorderName = SelectAssetName.CourseBorderRightGaiden;
+                //        break;
+                //    case CourseBackground.Wood:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftKyuu;
+                //        rightBorderName = SelectAssetName.CourseBorderRightKyuu;
+                //        break;
+                //    case CourseBackground.Blue:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftBlue;
+                //        rightBorderName = SelectAssetName.CourseBorderRightBlue;
+                //        break;
+                //    case CourseBackground.Red:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftRed;
+                //        rightBorderName = SelectAssetName.CourseBorderRightRed;
+                //        break;
+                //    case CourseBackground.Silver:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftSilver;
+                //        rightBorderName = SelectAssetName.CourseBorderRightSilver;
+                //        break;
+                //    case CourseBackground.Gold:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftGold;
+                //        rightBorderName = SelectAssetName.CourseBorderRightGold;
+                //        break;
+                //    default:
+                //        leftBorderName = SelectAssetName.CourseBorderLeftGaiden;
+                //        rightBorderName = SelectAssetName.CourseBorderRightGaiden;
+                //        break;
+                //}
+                AssetUtility.CreateImageChild(courseObject, "LeftBorder", new Vector2(22, 33), Path.Combine("Course", "CourseSelect", "Borders", "Left", borderFileName));
+                AssetUtility.CreateImageChild(courseObject, "RightBorder", new Vector2(1458, 33), Path.Combine("Course", "CourseSelect", "Borders", "Right", borderFileName));
+                //DaniDojoAssetUtility.CreateImage("LeftBorder", GetAssetSprite(leftBorderName), new Vector2(22, 33), courseObject.transform);
+                //DaniDojoAssetUtility.CreateImage("RightBorder", GetAssetSprite(rightBorderName), new Vector2(1458, 33), courseObject.transform);
 
 
 
@@ -1068,113 +1337,128 @@ namespace DaniDojo.Patches
                 for (int i = 0; i < Math.Min(courseInfo.Songs.Count, 3); i++)
                 {
 
-                    GameObject songParent = DaniDojoAssetUtility.CreateImage("SongBg" + (i + 1), GetAssetSprite(SelectAssetName.SongTitleBg), new Vector2(78, 718 - (110 * i)), courseObject.transform);
-                    SelectAssetName songIndicator;
-                    if (i == 0)
-                    {
-                        songIndicator = SelectAssetName.SongIndicator1;
-                    }
-                    else if (i == 1)
-                    {
-                        songIndicator = SelectAssetName.SongIndicator2;
-                    }
-                    else
-                    {
-                        songIndicator = SelectAssetName.SongIndicator3;
-                    }
-                    DaniDojoAssetUtility.CreateImage("SongIndicator", GetAssetSprite(songIndicator), new Vector2(10, 10), songParent.transform);
+                    //GameObject songParent = DaniDojoAssetUtility.CreateImage("SongBg" + (i + 1), GetAssetSprite(SelectAssetName.SongTitleBg), new Vector2(78, 718 - (110 * i)), courseObject.transform);
+                    var songParent = AssetUtility.CreateImageChild(courseObject, "SongBg" + (i + 1), new Vector2(78, 718 - (110 * i)), Path.Combine("Select", "SongTitleBg.png"));
 
-                    var song = musicInfoAccessers.Find((x) => x.Id == courseInfo.Songs[i].SongId);
-                    string songTitle = "Song not found: ";
-                    if (Plugin.Instance.ConfigSongTitleLanguage.Value == "Jp")
-                    {
-                        songTitle += courseInfo.Songs[i].TitleJp;
-                    }
-                    else if (Plugin.Instance.ConfigSongTitleLanguage.Value == "Eng")
-                    {
-                        songTitle += courseInfo.Songs[i].TitleEng;
-                    }
-                    else
-                    {
-                        songTitle += courseInfo.Songs[i].SongId;
-                    }
-                    string songDetail = "";
-                    if (song != null)
-                    {
-                        songTitle = wordDataMgr.GetWordListInfo("song_" + song.Id).Text;
-                        songDetail = wordDataMgr.GetWordListInfo("song_detail_" + song.Id).Text;
-                    }
+                    //SelectAssetName songIndicator;
+                    //if (i == 0)
+                    //{
+                    //    songIndicator = SelectAssetName.SongIndicator1;
+                    //}
+                    //else if (i == 1)
+                    //{
+                    //    songIndicator = SelectAssetName.SongIndicator2;
+                    //}
+                    //else
+                    //{
+                    //    songIndicator = SelectAssetName.SongIndicator3;
+                    //}
+                    //DaniDojoAssetUtility.CreateImage("SongIndicator", GetAssetSprite(songIndicator), new Vector2(10, 10), songParent.transform);
+                    AssetUtility.CreateImageChild(songParent, "SongIndicator", new Vector2(10, 10), Path.Combine("Select", "SongIndicator" + (i + 1) + ".png"));
 
-                    if (courseInfo.Songs[i].IsHidden)
-                    {
-                        // SongReached is 0 indexed
-                        if (highScore.SongReached <= i)
-                        {
-                            songTitle = "? ? ?";
-                            songDetail = "";
-                        }
-                    }
+                    //var song = musicInfoAccessers.Find((x) => x.Id == courseInfo.Songs[i].SongId);
+                    //string songTitle = "Song not found: ";
+                    //if (Plugin.Instance.ConfigSongTitleLanguage.Value == "Jp")
+                    //{
+                    //    songTitle += courseInfo.Songs[i].TitleJp;
+                    //}
+                    //else if (Plugin.Instance.ConfigSongTitleLanguage.Value == "Eng")
+                    //{
+                    //    songTitle += courseInfo.Songs[i].TitleEng;
+                    //}
+                    //else
+                    //{
+                    //    songTitle += courseInfo.Songs[i].SongId;
+                    //}
+                    //string songDetail = "";
+                    //if (song != null)
+                    //{
+                    //    songTitle = wordDataMgr.GetWordListInfo("song_" + song.Id).Text;
+                    //    songDetail = wordDataMgr.GetWordListInfo("song_detail_" + song.Id).Text;
+                    //}
 
-
-                    SelectAssetName levelAssetName;
-                    switch (courseInfo.Songs[i].Level)
-                    {
-                        case EnsoData.EnsoLevelType.Easy: levelAssetName = SelectAssetName.CourseEasy; break;
-                        case EnsoData.EnsoLevelType.Normal: levelAssetName = SelectAssetName.CourseNormal; break;
-                        case EnsoData.EnsoLevelType.Hard: levelAssetName = SelectAssetName.CourseHard; break;
-                        case EnsoData.EnsoLevelType.Mania: levelAssetName = SelectAssetName.CourseOni; break;
-                        case EnsoData.EnsoLevelType.Ura: levelAssetName = SelectAssetName.CourseUra; break;
-                        default: levelAssetName = SelectAssetName.CourseOni; break;
-                    }
-                    DaniDojoAssetUtility.CreateImage("SongCourse", GetAssetSprite(levelAssetName), new Vector2(112, 42), songParent.transform);
-
-                    SelectAssetName starAssetName;
-
-                    if (song != null)
-                    {
-                        switch (song.Stars[(int)courseInfo.Songs[i].Level])
-                        {
-                            case 1: starAssetName = SelectAssetName.Star1; break;
-                            case 2: starAssetName = SelectAssetName.Star2; break;
-                            case 3: starAssetName = SelectAssetName.Star3; break;
-                            case 4: starAssetName = SelectAssetName.Star4; break;
-                            case 5: starAssetName = SelectAssetName.Star5; break;
-                            case 6: starAssetName = SelectAssetName.Star6; break;
-                            case 7: starAssetName = SelectAssetName.Star7; break;
-                            case 8: starAssetName = SelectAssetName.Star8; break;
-                            case 9: starAssetName = SelectAssetName.Star9; break;
-                            case 10: starAssetName = SelectAssetName.Star10; break;
-                            default: starAssetName = SelectAssetName.Star10Plus; break; // Might as well have this as a default, it's kinda fun
-                        }
-                    }
-                    else
-                    {
-                        starAssetName = SelectAssetName.Star10Plus;
-                    }
-
-                    DaniDojoAssetUtility.CreateImage("SongLevel", GetAssetSprite(starAssetName), new Vector2(121, 15), songParent.transform);
-
-                    Rect titleRect = new Rect(220, 28, 1920, 40);
-                    Rect detailRect = new Rect(220, 70, 1920, 20);
+                    //if (courseInfo.Songs[i].IsHidden)
+                    //{
+                    //    // SongReached is 0 indexed
+                    //    if (highScore.SongReached <= i)
+                    //    {
+                    //        songTitle = "? ? ?";
+                    //        songDetail = "";
+                    //    }
+                    //}
 
 
+                    //SelectAssetName levelAssetName;
+                    //switch (courseInfo.Songs[i].Level)
+                    //{
+                    //    case EnsoData.EnsoLevelType.Easy: levelAssetName = SelectAssetName.CourseEasy; break;
+                    //    case EnsoData.EnsoLevelType.Normal: levelAssetName = SelectAssetName.CourseNormal; break;
+                    //    case EnsoData.EnsoLevelType.Hard: levelAssetName = SelectAssetName.CourseHard; break;
+                    //    case EnsoData.EnsoLevelType.Mania: levelAssetName = SelectAssetName.CourseOni; break;
+                    //    case EnsoData.EnsoLevelType.Ura: levelAssetName = SelectAssetName.CourseUra; break;
+                    //    default: levelAssetName = SelectAssetName.CourseOni; break;
+                    //}
+                    //DaniDojoAssetUtility.CreateImage("SongCourse", GetAssetSprite(levelAssetName), new Vector2(112, 42), songParent.transform);
+
+                    //SelectAssetName starAssetName;
+
+                    //if (song != null)
+                    //{
+                    //    switch (song.Stars[(int)courseInfo.Songs[i].Level])
+                    //    {
+                    //        case 1: starAssetName = SelectAssetName.Star1; break;
+                    //        case 2: starAssetName = SelectAssetName.Star2; break;
+                    //        case 3: starAssetName = SelectAssetName.Star3; break;
+                    //        case 4: starAssetName = SelectAssetName.Star4; break;
+                    //        case 5: starAssetName = SelectAssetName.Star5; break;
+                    //        case 6: starAssetName = SelectAssetName.Star6; break;
+                    //        case 7: starAssetName = SelectAssetName.Star7; break;
+                    //        case 8: starAssetName = SelectAssetName.Star8; break;
+                    //        case 9: starAssetName = SelectAssetName.Star9; break;
+                    //        case 10: starAssetName = SelectAssetName.Star10; break;
+                    //        default: starAssetName = SelectAssetName.Star10Plus; break; // Might as well have this as a default, it's kinda fun
+                    //    }
+                    //}
+                    //else
+                    //{
+                    //    starAssetName = SelectAssetName.Star10Plus;
+                    //}
+
+                    //DaniDojoAssetUtility.CreateImage("SongLevel", GetAssetSprite(starAssetName), new Vector2(121, 15), songParent.transform);
 
 
-                    DaniDojoAssetUtility.CreateText("SongTitle", songTitle, titleRect, titleFont, titleFontMaterial, HorizontalAlignmentOptions.Left, Color.black, songParent.transform);
-                    var detail = DaniDojoAssetUtility.CreateText("SongDetail", songDetail, detailRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Left, Color.black, songParent.transform);
-                    detail.GetComponent<TextMeshProUGUI>().color = Color.black;
+                    CommonAssets.CreateSongCourseChild(songParent, new Vector2(112, 42), courseInfo.Songs[i]);
+
+                    CommonAssets.CreateSongLevelChild(songParent, new Vector2(121, 15), courseInfo.Songs[i]);
+
+
+                    Vector2 titleRect = new Vector2(220, 28);
+                    Vector2 detailRect = new Vector2(220, 70);
+
+                    CommonAssets.CreateSongTitleChild(songParent, titleRect, courseInfo.Songs[i], courseInfo.Songs[i].IsHidden && highScore.SongReached <= i);
+                    CommonAssets.CreateSongDetailChild(songParent, detailRect, courseInfo.Songs[i], courseInfo.Songs[i].IsHidden && highScore.SongReached <= i);
+
+
+
+                    //DaniDojoAssetUtility.CreateText("SongTitle", songTitle, titleRect, titleFont, titleFontMaterial, HorizontalAlignmentOptions.Left, Color.black, songParent.transform);
+                    //var detail = DaniDojoAssetUtility.CreateText("SongDetail", songDetail, detailRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Left, Color.black, songParent.transform);
+                    //detail.GetComponent<TextMeshProUGUI>().color = Color.black;
 
                 }
 
 
                 // Add Requirements info
-                DaniDojoAssetUtility.CreateImage("RequirementsMainPanel", GetAssetSprite(SelectAssetName.RequirementsMainPanel), new Vector2(78, 417), courseObject.transform);
-                DaniDojoAssetUtility.CreateImage("RequirementsPanelLeftBorder", GetAssetSprite(SelectAssetName.RequirementsPanelBorder), new Vector2(78, 33), courseObject.transform);
-                DaniDojoAssetUtility.CreateImage("RequirementsPanelRightBorder", GetAssetSprite(SelectAssetName.RequirementsPanelBorder), new Vector2(1440, 33), courseObject.transform);
+                //DaniDojoAssetUtility.CreateImage("RequirementsMainPanel", GetAssetSprite(SelectAssetName.RequirementsMainPanel), new Vector2(78, 412), courseObject.transform);
+                //DaniDojoAssetUtility.CreateImage("RequirementsPanelLeftBorder", GetAssetSprite(SelectAssetName.RequirementsPanelBorder), new Vector2(78, 33), courseObject.transform);
+                //DaniDojoAssetUtility.CreateImage("RequirementsPanelRightBorder", GetAssetSprite(SelectAssetName.RequirementsPanelBorder), new Vector2(1440, 33), courseObject.transform);
 
+                AssetUtility.CreateImageChild(courseObject, "RequirementsMainPanel", new Vector2(78, 417), Path.Combine("Select", "RequirementsMainPanel"));
+                AssetUtility.CreateImageChild(courseObject, "RequirementsPanelLeftBorder", new Vector2(78, 33), Path.Combine("Select", "RequirementsPanelBorder"));
+                AssetUtility.CreateImageChild(courseObject, "RequirementsPanelRightBorder", new Vector2(1440, 33), Path.Combine("Select", "RequirementsPanelBorder"));
 
                 // Add Soul Gauge Requirements
-                var SoulGaugeReqPanel = DaniDojoAssetUtility.CreateImage("SoulGaugeReqPanel", GetAssetSprite(SelectAssetName.SoulGaugeReqPanel), new Vector2(94, 268), courseObject.transform);
+                //var SoulGaugeReqPanel = DaniDojoAssetUtility.CreateImage("SoulGaugeReqPanel", GetAssetSprite(SelectAssetName.SoulGaugeReqPanel), new Vector2(94, 268), courseObject.transform);
+                var SoulGaugeReqPanel = AssetUtility.CreateImageChild(courseObject, "SoulGaugeReqPanel", new Vector2(94, 268), Path.Combine("Select", "SoulGaugeReqPanel"));
 
 
                 TMP_FontAsset reqTypeFont = fontTMPMgr.GetDefaultFontAsset(DataConst.FontType.EFIGS);
@@ -1184,7 +1468,10 @@ namespace DaniDojo.Patches
                 Material reqValueFontMaterial = fontTMPMgr.GetDescriptionFontMaterial(DataConst.FontType.EFIGS, DataConst.DescriptionFontMaterialType.OutlineSongInfo);
 
                 Rect SoulGaugeHeaderRect = new Rect(40, 139, 240, 25);
-                DaniDojoAssetUtility.CreateText("SoulGaugeHeader", "Soul Gauge", SoulGaugeHeaderRect, reqTypeFont, reqTypeFontMaterial, HorizontalAlignmentOptions.Center, new Color32(74, 64, 51, 255), SoulGaugeReqPanel.transform);
+                //DaniDojoAssetUtility.CreateText("SoulGaugeHeader", "Soul Gauge", SoulGaugeHeaderRect, reqTypeFont, reqTypeFontMaterial, HorizontalAlignmentOptions.Center, new Color32(74, 64, 51, 255), SoulGaugeReqPanel.transform);
+                var soulGaugeHeader = AssetUtility.CreateTextChild(SoulGaugeReqPanel, "SoulGaugeHeader", SoulGaugeHeaderRect, "Soul Gauge");
+                AssetUtility.SetTextFontAndMaterial(soulGaugeHeader, reqTypeFont, reqTypeFontMaterial);
+                AssetUtility.SetTextAlignment(soulGaugeHeader, HorizontalAlignmentOptions.Center);
 
                 int soulGaugeRequirement = 100;
                 for (int i = 0; i < courseInfo.Borders.Count; i++)
@@ -1197,17 +1484,30 @@ namespace DaniDojo.Patches
                 }
 
                 Rect SoulGaugeReqValueRect = new Rect(50, 73, 256, 39);
-                DaniDojoAssetUtility.CreateText("SoulGaugeReqValue", soulGaugeRequirement.ToString() + "% or higher", SoulGaugeReqValueRect, reqValueFont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), SoulGaugeReqPanel.transform);
+                //DaniDojoAssetUtility.CreateText("SoulGaugeReqValue", soulGaugeRequirement.ToString() + "% or higher", SoulGaugeReqValueRect, reqValueFont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), SoulGaugeReqPanel.transform);
+                var soulGaugeReqValue = AssetUtility.CreateTextChild(SoulGaugeReqPanel, "SoulGaugeReqValue", SoulGaugeReqValueRect, soulGaugeRequirement.ToString() + "% or higher");
+                AssetUtility.SetTextFontAndMaterial(soulGaugeReqValue, reqValueFont, reqValueFontMaterial);
+                AssetUtility.SetTextAlignment(soulGaugeReqValue, HorizontalAlignmentOptions.Right);
 
                 if (highScore.SongReached > 0)
                 {
                     Rect SoulGaugeHighScoreHeaderRect = new Rect(12, 27, 100, 25);
-                    var SoulGaugeHighScoreHeader = DaniDojoAssetUtility.CreateText("SoulGaugeHighScoreHeader", "High Score", SoulGaugeHighScoreHeaderRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Left, new Color32(0, 0, 0, 0), SoulGaugeReqPanel.transform);
-                    SoulGaugeHighScoreHeader.GetComponent<TextMeshProUGUI>().color = Color.black;
+                    //var SoulGaugeHighScoreHeader = DaniDojoAssetUtility.CreateText("SoulGaugeHighScoreHeader", "High Score", SoulGaugeHighScoreHeaderRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Left, new Color32(0, 0, 0, 0), SoulGaugeReqPanel.transform);
+                    //SoulGaugeHighScoreHeader.GetComponent<TextMeshProUGUI>().color = Color.black;
+
+                    var SoulGaugeHighScoreHeader = AssetUtility.CreateTextChild(SoulGaugeReqPanel, "SoulGaugeHighScoreHeader", SoulGaugeHighScoreHeaderRect, "High Score");
+                    AssetUtility.SetTextFontAndMaterial(SoulGaugeHighScoreHeader, detailFont, detailFontMaterial);
+                    AssetUtility.SetTextAlignment(SoulGaugeHighScoreHeader, HorizontalAlignmentOptions.Left);
+                    AssetUtility.SetTextColor(SoulGaugeHighScoreHeader, Color.black);
 
                     Rect SoulGaugeHighScoreValueRect = new Rect(200, 20, 100, 40);
-                    var SoulGaugeHighScoreValue = DaniDojoAssetUtility.CreateText("SoulGaugeHighScoreValue", highScore.PlayData.Max((x) => x.SoulGauge).ToString() + " %", SoulGaugeHighScoreValueRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Right, new Color32(0, 0, 0, 0), SoulGaugeReqPanel.transform);
-                    SoulGaugeHighScoreValue.GetComponent<TextMeshProUGUI>().color = Color.black;
+                    //var SoulGaugeHighScoreValue = DaniDojoAssetUtility.CreateText("SoulGaugeHighScoreValue", highScore.PlayData.Max((x) => x.SoulGauge).ToString() + " %", SoulGaugeHighScoreValueRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Right, new Color32(0, 0, 0, 0), SoulGaugeReqPanel.transform);
+                    //SoulGaugeHighScoreValue.GetComponent<TextMeshProUGUI>().color = Color.black;
+
+                    var SoulGaugeHighScoreValue = AssetUtility.CreateTextChild(SoulGaugeReqPanel, "SoulGaugeHighScoreValue", SoulGaugeHighScoreValueRect, highScore.PlayData.Max((x) => x.SoulGauge).ToString() + " %");
+                    AssetUtility.SetTextFontAndMaterial(SoulGaugeHighScoreValue, detailFont, detailFontMaterial);
+                    AssetUtility.SetTextAlignment(SoulGaugeHighScoreValue, HorizontalAlignmentOptions.Right);
+                    AssetUtility.SetTextColor(SoulGaugeHighScoreValue, Color.black);
                 }
 
 
@@ -1220,7 +1520,8 @@ namespace DaniDojo.Patches
                         passedSoulGauge = true;
                         continue;
                     }
-                    var reqPanel = DaniDojoAssetUtility.CreateImage("ReqPanel" + (i + 1), GetAssetSprite(SelectAssetName.RequirementsEachPanel), new Vector2(427, 310 - (passedSoulGauge ? (i - 1) * 132 : i * 132)), courseObject.transform);
+                    //var reqPanel = DaniDojoAssetUtility.CreateImage("ReqPanel" + (i + 1), GetAssetSprite(SelectAssetName.RequirementsEachPanel), new Vector2(427, 310 - (passedSoulGauge ? (i - 1) * 132 : i * 132)), courseObject.transform);
+                    var reqPanel = AssetUtility.CreateImageChild(courseObject, "ReqPanel" + (i + 1), new Vector2(427, 310 - (passedSoulGauge ? (i - 1) * 132 : i * 132)), Path.Combine("Select", "RequirementsEachPanel.png"));
 
                     Rect reqPanelHeaderRect = new Rect(34, 95, 240, 25);
                     string requirementTypeText = string.Empty;
@@ -1234,11 +1535,17 @@ namespace DaniDojo.Patches
                         case BorderType.Score: requirementTypeText = "Score"; break;
                         case BorderType.TotalHits: requirementTypeText = "Total Hits"; break;
                     }
-                    DaniDojoAssetUtility.CreateText("SoulGaugeHeader", requirementTypeText, reqPanelHeaderRect, reqTypeFont, reqTypeFontMaterial, HorizontalAlignmentOptions.Center, new Color32(74, 64, 51, 255), reqPanel.transform);
+                    //DaniDojoAssetUtility.CreateText("SoulGaugeHeader", requirementTypeText, reqPanelHeaderRect, reqTypeFont, reqTypeFontMaterial, HorizontalAlignmentOptions.Center, new Color32(74, 64, 51, 255), reqPanel.transform);
+                    var soulGaugeHeaderText = AssetUtility.CreateTextChild(reqPanel, "SoulGaugeHeader", reqPanelHeaderRect, requirementTypeText);
+                    AssetUtility.SetTextFontAndMaterial(soulGaugeHeaderText, reqTypeFont, reqTypeFontMaterial);
+                    AssetUtility.SetTextAlignment(soulGaugeHeaderText, HorizontalAlignmentOptions.Center);
+
 
                     if (courseInfo.Borders[i].IsTotal)
                     {
-                        var reqPanelValue = DaniDojoAssetUtility.CreateImage("ReqPanelValue" + (i + 1), GetAssetSprite(SelectAssetName.ReqSongIndicatorTotal), new Vector2(14, 49), reqPanel.transform);
+                        //var reqPanelValue = DaniDojoAssetUtility.CreateImage("ReqPanelValue" + (i + 1), GetAssetSprite(SelectAssetName.ReqSongIndicatorTotal), new Vector2(14, 49), reqPanel.transform);
+                        var reqPanelValue = AssetUtility.CreateImageChild(reqPanel, "ReqPanelValue" + (i + 1), new Vector2(14, 49), Path.Combine("Select", "ReqSongIndicatorTotal.png"));
+
 
                         string valueText = string.Empty;
                         if (courseInfo.Borders[i].BorderType == BorderType.Oks || courseInfo.Borders[i].BorderType == BorderType.Bads)
@@ -1250,9 +1557,15 @@ namespace DaniDojo.Patches
                             valueText = courseInfo.Borders[i].RedReqs[0] + " or more";
                         }
                         Rect reqValueRect = new Rect(50, 0, 256, 31);
-                        DaniDojoAssetUtility.CreateText("ReqValue" + (i + 1), valueText, reqValueRect, reqValueFont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), reqPanelValue.transform);
+                        //DaniDojoAssetUtility.CreateText("ReqValue" + (i + 1), valueText, reqValueRect, reqValueFont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), reqPanelValue.transform);
+                        var reqValueText = AssetUtility.CreateTextChild(reqPanelValue, "ReqValue" + (i + 1), reqValueRect, valueText);
+                        AssetUtility.SetTextFontAndMaterial(reqValueText, reqValueFont, reqValueFontMaterial);
+                        AssetUtility.SetTextAlignment(reqValueText, HorizontalAlignmentOptions.Right);
 
-                        var reqPanelBest = DaniDojoAssetUtility.CreateImage("ReqPanelBest" + (i + 1), GetAssetSprite(SelectAssetName.PersonalBestBg), new Vector2(14, 11), reqPanel.transform);
+
+                        //var reqPanelBest = DaniDojoAssetUtility.CreateImage("ReqPanelBest" + (i + 1), GetAssetSprite(SelectAssetName.PersonalBestBg), new Vector2(14, 11), reqPanel.transform);
+                        var reqPanelBest = AssetUtility.CreateImageChild(reqPanel, "ReqPanelBest" + (i + 1), new Vector2(14, 11), Path.Combine("Select", "PersonalBestBg.png"));
+
 
                         if (highScore.SongReached > 0)
                         {
@@ -1273,7 +1586,10 @@ namespace DaniDojo.Patches
                             }
 
                             Rect highScoreValueRect = new Rect(200, -3, 100, 35);
-                            var highScoreValue = DaniDojoAssetUtility.CreateText("HighScoreValue", highScoreValueText, highScoreValueRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Right, new Color32(0, 0, 0, 0), reqPanelBest.transform);
+                            //var highScoreValue = DaniDojoAssetUtility.CreateText("HighScoreValue", highScoreValueText, highScoreValueRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Right, new Color32(0, 0, 0, 0), reqPanelBest.transform);
+                            var highScoreValue = AssetUtility.CreateTextChild(reqPanelBest, "HighScoreValue", highScoreValueRect, highScoreValueText);
+                            AssetUtility.SetTextFontAndMaterial(highScoreValue, detailFont, detailFontMaterial);
+                            AssetUtility.SetTextAlignment(highScoreValue, HorizontalAlignmentOptions.Right);
                             highScoreValue.GetComponent<TextMeshProUGUI>().color = Color.black;
                         }
                     }
@@ -1282,16 +1598,17 @@ namespace DaniDojo.Patches
                         for (int j = 0; j < Math.Min(courseInfo.Songs.Count, 3); j++)
                         {
                             int xOffset = (326 * j);
-                            SelectAssetName SongIndicatorAsset = SelectAssetName.ReqSongIndicator1;
-                            if (j == 1)
-                            {
-                                SongIndicatorAsset = SelectAssetName.ReqSongIndicator2;
-                            }
-                            else if (j == 2)
-                            {
-                                SongIndicatorAsset = SelectAssetName.ReqSongIndicator3;
-                            }
-                            var reqPanelValue = DaniDojoAssetUtility.CreateImage("ReqPanelValue" + (j + 1), GetAssetSprite(SongIndicatorAsset), new Vector2(14 + xOffset, 49), reqPanel.transform);
+                            //SelectAssetName SongIndicatorAsset = SelectAssetName.ReqSongIndicator1;
+                            //if (j == 1)
+                            //{
+                            //    SongIndicatorAsset = SelectAssetName.ReqSongIndicator2;
+                            //}
+                            //else if (j == 2)
+                            //{
+                            //    SongIndicatorAsset = SelectAssetName.ReqSongIndicator3;
+                            //}
+                            //var reqPanelValue = DaniDojoAssetUtility.CreateImage("ReqPanelValue" + (j + 1), GetAssetSprite(SongIndicatorAsset), new Vector2(14 + xOffset, 49), reqPanel.transform);
+                            var reqPanelValue = AssetUtility.CreateImageChild(reqPanel, "ReqPanelValue" + (j + 1), new Vector2(14 + xOffset, 49), Path.Combine("Select", "ReqSongIndicator" + (j + 1) + ".png"));
                             string valueText = string.Empty;
                             if (courseInfo.Borders[i].BorderType == BorderType.Oks || courseInfo.Borders[i].BorderType == BorderType.Bads)
                             {
@@ -1302,9 +1619,15 @@ namespace DaniDojo.Patches
                                 valueText = courseInfo.Borders[i].RedReqs[j] + " or more";
                             }
                             Rect reqValueRect = new Rect(50, 0, 256, 31);
-                            DaniDojoAssetUtility.CreateText("ReqValue" + (i + 1), valueText, reqValueRect, reqValueFont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), reqPanelValue.transform);
+                            //DaniDojoAssetUtility.CreateText("ReqValue" + (i + 1), valueText, reqValueRect, reqValueFont, reqValueFontMaterial, HorizontalAlignmentOptions.Right, new Color32(74, 64, 51, 255), reqPanelValue.transform);
+                            var reqValueText = AssetUtility.CreateTextChild(reqPanelValue, "ReqValue" + (i + 1), reqValueRect, valueText);
+                            AssetUtility.SetTextFontAndMaterial(reqValueText, reqValueFont, reqValueFontMaterial);
+                            AssetUtility.SetTextAlignment(reqValueText, HorizontalAlignmentOptions.Right);
 
-                            var reqPanelBest = DaniDojoAssetUtility.CreateImage("ReqPanelBest" + (j + 1), GetAssetSprite(SelectAssetName.PersonalBestBg), new Vector2(14 + xOffset, 11), reqPanel.transform);
+
+                            //var reqPanelBest = DaniDojoAssetUtility.CreateImage("ReqPanelBest" + (j + 1), GetAssetSprite(SelectAssetName.PersonalBestBg), new Vector2(14 + xOffset, 11), reqPanel.transform);
+                            var reqPanelBest = AssetUtility.CreateImageChild(reqPanel, "ReqPanelBest" + (j + 1), new Vector2(14 + xOffset, 11), Path.Combine("Select", "PersonalBestBg.png"));
+
 
                             // SongReached of 0 means it wasn't played
                             if (highScore.SongReached > 0)
@@ -1326,88 +1649,90 @@ namespace DaniDojo.Patches
                                 }
 
                                 Rect highScoreValueRect = new Rect(200, -3, 100, 35);
-                                var highScoreValue = DaniDojoAssetUtility.CreateText("HighScoreValue", highScoreValueText, highScoreValueRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Right, new Color32(0, 0, 0, 0), reqPanelBest.transform);
-                                highScoreValue.GetComponent<TextMeshProUGUI>().color = Color.black;
+                                //var highScoreValue = DaniDojoAssetUtility.CreateText("HighScoreValue", highScoreValueText, highScoreValueRect, detailFont, detailFontMaterial, HorizontalAlignmentOptions.Right, new Color32(0, 0, 0, 0), reqPanelBest.transform);
+                                //highScoreValue.GetComponent<TextMeshProUGUI>().color = Color.black;
+                                var highScoreValue = AssetUtility.CreateTextChild(reqPanelBest, "HighScoreValue", highScoreValueRect, highScoreValueText);
+                                AssetUtility.SetTextFontAndMaterial(highScoreValue, detailFont, detailFontMaterial);
+                                AssetUtility.SetTextAlignment(highScoreValue, HorizontalAlignmentOptions.Right);
+                                AssetUtility.SetTextColor(highScoreValue, Color.black);
+
                             }
                         }
                     }
 
                 }
 
-                var bgImage = courseInfo.Background switch
-                {
-                    CourseBackground.Wood => SelectAssetName.WoodBg,
-                    CourseBackground.Blue => SelectAssetName.BlueBg,
-                    CourseBackground.Red => SelectAssetName.RedBg,
-                    CourseBackground.Silver => SelectAssetName.SilverBg,
-                    CourseBackground.Gold => SelectAssetName.GoldBg,
-                    _ => SelectAssetName.TanBg,
-                };
-
-                var courseId = courseInfo.Id;
-                if (int.TryParse(courseId, out int _))
-                {
-                    courseId = courseInfo.Title;
-                }
-
-                var textImage = courseId switch
-                {
-                    "5kyuu" or "五級 5th Kyu" => SelectAssetName.kyuu5,
-                    "4kyuu" or "四級 4th Kyu" => SelectAssetName.kyuu4,
-                    "3kyuu" or "三級 3rd Kyu" => SelectAssetName.kyuu3,
-                    "2kyuu" or "二級 2nd Kyu" => SelectAssetName.kyuu2,
-                    "1kyuu" or "一級 1st Kyu" => SelectAssetName.kyuu1,
-                    "1dan" or "初段 1st Dan" => SelectAssetName.dan1,
-                    "2dan" or "二段 2nd Dan" => SelectAssetName.dan2,
-                    "3dan" or "三段 3rd Dan" => SelectAssetName.dan3,
-                    "4dan" or "四段 4th Dan" => SelectAssetName.dan4,
-                    "5dan" or "五段 5th Dan" => SelectAssetName.dan5,
-                    "6dan" or "六段 6th Dan" => SelectAssetName.dan6,
-                    "7dan" or "七段 7th Dan" => SelectAssetName.dan7,
-                    "8dan" or "八段 8th Dan" => SelectAssetName.dan8,
-                    "9dan" or "九段 9th Dan" => SelectAssetName.dan9,
-                    "10dan" or "十段 10th Dan" => SelectAssetName.dan10,
-                    "11dan" or "玄人 Kuroto" => SelectAssetName.kuroto,
-                    "12dan" or "名人 Meijin" => SelectAssetName.meijin,
-                    "13dan" or "超人 Chojin" => SelectAssetName.chojin,
-                    "14dan" or "達人 Tatsujin" => SelectAssetName.tatsujin,
-                    _ => SelectAssetName.gaiden,
-                };
-
                 var baseCourseTagPos = new Vector2(-212, 332);
-                DaniDojoAssetUtility.CreateImage("CurrentDanMarkerBack", GetAssetSprite(bgImage), baseCourseTagPos, courseObject.transform);
-                DaniDojoAssetUtility.CreateImage("CurrentDanMarkerText", GetAssetSprite(textImage), new Vector2(baseCourseTagPos.x + 52, baseCourseTagPos.y + 124), courseObject.transform);
 
 
-                if (highScore.SongReached > 0)
+                CommonAssets.CreateDaniCourse(courseObject, baseCourseTagPos, courseInfo);
+                CommonAssets.CreateCourseTitleBar(courseObject, new Vector2(21, 822), courseInfo);
+
+                //else
+                //{
+                //    var bgImage = courseInfo.Background switch
+                //    {
+                //        CourseBackground.Wood => SelectAssetName.WoodBg,
+                //        CourseBackground.Blue => SelectAssetName.BlueBg,
+                //        CourseBackground.Red => SelectAssetName.RedBg,
+                //        CourseBackground.Silver => SelectAssetName.SilverBg,
+                //        CourseBackground.Gold => SelectAssetName.GoldBg,
+                //        _ => SelectAssetName.TanBg,
+                //    };
+
+                //    var courseId = courseInfo.Id;
+                //    if (int.TryParse(courseId, out int _))
+                //    {
+                //        courseId = courseInfo.Title;
+                //    }
+
+                //    var textImage = courseId switch
+                //    {
+                //        "5kyuu" or "五級 5th Kyu" => SelectAssetName.kyuu5,
+                //        "4kyuu" or "四級 4th Kyu" => SelectAssetName.kyuu4,
+                //        "3kyuu" or "三級 3rd Kyu" => SelectAssetName.kyuu3,
+                //        "2kyuu" or "二級 2nd Kyu" => SelectAssetName.kyuu2,
+                //        "1kyuu" or "一級 1st Kyu" => SelectAssetName.kyuu1,
+                //        "1dan" or "初段 1st Dan" => SelectAssetName.dan1,
+                //        "2dan" or "二段 2nd Dan" => SelectAssetName.dan2,
+                //        "3dan" or "三段 3rd Dan" => SelectAssetName.dan3,
+                //        "4dan" or "四段 4th Dan" => SelectAssetName.dan4,
+                //        "5dan" or "五段 5th Dan" => SelectAssetName.dan5,
+                //        "6dan" or "六段 6th Dan" => SelectAssetName.dan6,
+                //        "7dan" or "七段 7th Dan" => SelectAssetName.dan7,
+                //        "8dan" or "八段 8th Dan" => SelectAssetName.dan8,
+                //        "9dan" or "九段 9th Dan" => SelectAssetName.dan9,
+                //        "10dan" or "十段 10th Dan" => SelectAssetName.dan10,
+                //        "11dan" or "玄人 Kuroto" => SelectAssetName.kuroto,
+                //        "12dan" or "名人 Meijin" => SelectAssetName.meijin,
+                //        "13dan" or "超人 Chojin" => SelectAssetName.chojin,
+                //        "14dan" or "達人 Tatsujin" => SelectAssetName.tatsujin,
+                //        _ => SelectAssetName.gaiden,
+                //    };
+
+                //    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerBack", GetAssetSprite(bgImage), baseCourseTagPos, courseObject.transform);
+                //    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerText", GetAssetSprite(textImage), new Vector2(baseCourseTagPos.x + 52, baseCourseTagPos.y + 124), courseObject.transform);
+                //}
+
+                if (highScore.RankCombo.Rank != DaniRank.None)
                 {
-                    bool skip = false;
-                    SelectAssetName resultAsset = SelectAssetName.CourseNormal;
-                    if (highScore.RankCombo.Rank == DaniRank.GoldClear)
+                    string recordName = "Big";
+
+                    switch (highScore.RankCombo.Rank)
                     {
-                        switch (highScore.RankCombo.Combo)
-                        {
-                            case DaniCombo.Silver: resultAsset = SelectAssetName.BigGoldClear; break;
-                            case DaniCombo.Gold: resultAsset = SelectAssetName.BigGoldFC; break;
-                            case DaniCombo.Rainbow: resultAsset = SelectAssetName.BigGoldDFC; break;
-                        }
+                        case DaniRank.RedClear: recordName += "Red"; break;
+                        case DaniRank.GoldClear: recordName += "Gold"; break;
                     }
-                    else if (highScore.RankCombo.Rank == DaniRank.RedClear)
+                    switch (highScore.RankCombo.Combo) // Rename these files
                     {
-                        switch (highScore.RankCombo.Combo)
-                        {
-                            case DaniCombo.Silver: resultAsset = SelectAssetName.BigRedClear; break;
-                            case DaniCombo.Gold: resultAsset = SelectAssetName.BigRedFC; break;
-                            case DaniCombo.Rainbow: resultAsset = SelectAssetName.BigRedDFC; break;
-                        }
+                        case DaniCombo.Silver: recordName += "Clear"; break;
+                        case DaniCombo.Gold: recordName += "FC"; break;
+                        case DaniCombo.Rainbow: recordName += "DFC"; break;
                     }
 
-                    if (resultAsset != SelectAssetName.CourseNormal)
-                    {
-                        DaniDojoAssetUtility.CreateImage("DanResult", GetAssetSprite(resultAsset), new Vector2(-242, 291), courseObject.transform);
-                    }
+                    // DaniDojoAssetUtility.CreateImage(seriesInfo.Courses[i].Title + "Record", GetAssetSprite(recordName), new Vector2(0, 98), topCourseObject.transform);
+                    AssetUtility.CreateImageChild(courseObject, "DanResult", new Vector2(-242, 291), Path.Combine("Select", "ResultIcons", "Big", recordName + ".png")); // IDK what the file path will be
                 }
-
 
                 return courseObject;
             }

--- a/DaniDojo/OldPatches/DaniDojoTempEnso.cs
+++ b/DaniDojo/OldPatches/DaniDojoTempEnso.cs
@@ -1,17 +1,21 @@
 ﻿using App;
 using Blittables;
+using DaniDojo.Assets;
+using DaniDojo.Data;
+using DaniDojo.Hooks;
 using DaniDojo.Managers;
 using HarmonyLib;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using static DaniDojo.Patches.DaniDojoDaniCourseSelect;
 using static TaikoCoreTypes;
 
 namespace DaniDojo.Patches
@@ -35,7 +39,15 @@ namespace DaniDojo.Patches
                     //Plugin.LogInfo("frameResults.totalTime: " + frameResults.totalTime, 1);
                     //Plugin.LogInfo("__instance.songTime: " + __instance.songTime, 1);
                     //Plugin.LogInfo("frameResults.fumenLength: " + frameResults.fumenLength, 1);
-                    if (frameResults.totalTime < frameResults.fumenLength || frameResults.totalTime < __instance.songTime)
+                    //if (frameResults.totalTime < frameResults.fumenLength || frameResults.totalTime < __instance.songTime)
+                    //{
+                    //    //Plugin.Log.LogInfo("CheckEnsoEnd: totalTime less than fumen Length and song Time");
+                    //    return false;
+                    //}
+
+                    // 5 seconds after the final note of the song
+                    // Definitely not perfect, but better than what happened with magical parfait
+                    if (frameResults.totalTime < frameResults.fumenLength + 1000)
                     {
                         //Plugin.Log.LogInfo("CheckEnsoEnd: totalTime less than fumen Length and song Time");
                         return false;
@@ -43,8 +55,13 @@ namespace DaniDojo.Patches
 
                     if (DaniPlayManager.AdvanceSong())
                     {
-                        var songData = DaniPlayManager.GetSongData();
-                        BeginSong(songData.SongId, songData.Level);
+                        var courseData = DaniPlayManager.GetCurrentCourse();
+                        var songIndex = DaniPlayManager.GetCurrentSongNumber();
+                        AdvanceSong(courseData, songIndex);
+                    }
+                    else
+                    {
+                        CreateAssets = true;
                     }
                 }
             }
@@ -94,17 +111,29 @@ namespace DaniDojo.Patches
         //    }
         //}
 
-        public static void BeginSong(string songId, EnsoData.EnsoLevelType level)
+        static bool CreateAssets = true;
+
+        public static void BeginDan(DaniCourse course)
         {
+            // Loading screen here would be awesome
             Plugin.Log.LogInfo("BeginSong Start");
-            MusicDataInterface.MusicInfoAccesser musicInfoAccesser = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.MusicData.musicInfoAccessers.Find((MusicDataInterface.MusicInfoAccesser info) => info.Id == songId);
+            MusicDataInterface.MusicInfoAccesser musicInfoAccesser = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.MusicData.musicInfoAccessers.Find((MusicDataInterface.MusicInfoAccesser info) => info.Id == course.Songs[0].SongId);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoType = EnsoData.EnsoType.Normal;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.rankMatchType = EnsoData.RankMatchType.None;
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.musicuid = musicInfoAccesser.Id;
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.musicUniqueId = musicInfoAccesser.UniqueId;
-            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].courseType = level;
-            // To prevent highscores from showing up
-            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].hiScore = 2000000; 
-
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.genre = (EnsoData.SongGenre)musicInfoAccesser.GenreNo;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.playerNum = 1;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].neiroId = 0;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].courseType = course.Songs[0].Level;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].speed = DataConst.SpeedTypes.Normal;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].dron = DataConst.OptionOnOff.Off;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].reverse = DataConst.OptionOnOff.Off;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].randomlv = DataConst.RandomLevel.None;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].special = DataConst.SpecialTypes.None;
+            // To prevent highscores from showing up
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].hiScore = 2000000;
+
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.songFilePath = musicInfoAccesser.SongFileName;
 
             SystemOption systemOption;
@@ -113,111 +142,265 @@ namespace DaniDojo.Patches
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.noteDispOffset = (int)systemOption.onpuDispLevels[deviceTypeIndex];
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.noteDelay = (int)systemOption.onpuHitLevels[deviceTypeIndex];
 
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.songVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.InGameSong);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.seVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Se);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.voiceVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Voice);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.bgmVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Bgm);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.neiroVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.InGameNeiro);
+
+
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.SetSettings(ref TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings);
+
+            CreateAssets = true;
+
             TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySceneManager.ChangeRelayScene("Enso", false);
 
-            Plugin.Log.LogInfo("BeginSong End");
+            Plugin.Instance.StartCoroutine(CloseLaneCovers(true, course.Songs[0].SongId, (EnsoData.SongGenre)musicInfoAccesser.GenreNo));
         }
 
-        #region Note Counting
-        [HarmonyPatch(typeof(HitEffect))]
-        [HarmonyPatch(nameof(HitEffect.switchPlayAnimationOnpuTypes))]
-        [HarmonyPatch(MethodType.Normal)]
-        [HarmonyPostfix]
-        public static void HitEffect_switchPlayAnimationOnpuTypes_Postfix(HitEffect __instance, HitResultInfo info)
+        static IEnumerator CloseLaneCovers(bool isInitialClose, string songId, EnsoData.SongGenre genreNo)
         {
-            if (DaniPlayManager.CheckIsInDan())
+            PauseEnso(true);
+            while (!LoadingScreenHook.EndLoading)
             {
-                DaniPlayManager.AddHitResult(info);
-                int hitResult = info.hitResult;
-                if (info.onpuType == (int)OnpuTypes.Don || info.onpuType == (int)OnpuTypes.Do || info.onpuType == (int)OnpuTypes.Ko || info.onpuType == (int)OnpuTypes.Katsu || info.onpuType == (int)OnpuTypes.Ka
-                    || info.onpuType == (int)OnpuTypes.DaiDon || info.onpuType == (int)OnpuTypes.DaiKatsu
-                    || info.onpuType == (int)OnpuTypes.WDon || info.onpuType == (int)OnpuTypes.WKatsu)
-                {
-                    if (hitResult == (int)HitResultTypes.Fuka || hitResult == (int)HitResultTypes.Drop)
-                    {
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Bads);
-                    }
-                    else if (hitResult == (int)HitResultTypes.Ka)
-                    {
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Oks);
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.TotalHits);
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Combo);
-                        //DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Score);
-                    }
-                    else if (hitResult == (int)HitResultTypes.Ryo)
-                    {
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Goods);
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.TotalHits);
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Combo);
-                        //DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Score);
-                    }
-                }
-                else if (info.onpuType == (int)OnpuTypes.Renda || info.onpuType == (int)OnpuTypes.DaiRenda || info.onpuType == (int)OnpuTypes.Imo || info.onpuType == (int)OnpuTypes.GekiRenda)
-                {
-                    if (hitResult == (int)HitResultTypes.Ryo)
-                    {
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.TotalHits);
-                        DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Drumroll);
-                        //DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Score);
-                    }
-                }
+                yield return null;
+            }
+            GameObject canvasBack = null;
+            do
+            {
+                canvasBack = GameObject.Find("CanvasBack");
+                yield return null;
+            } while (canvasBack == null);
+
+            GameObject songInfoObject = null;
+            do
+            {
+                songInfoObject = GameObject.Find("SongInfo");
+                yield return null;
+            } while (songInfoObject == null);
+            var songInfoSongTitleObject = AssetUtility.GetChildByName(songInfoObject, "uiText_song_title_center");
+            var songInfoLayout = songInfoObject.GetComponent<SongInfoLayOut>();
+            var songInfoPlayer = songInfoObject.GetComponent<SongInfoPlayer>();
+
+            var laneSongTitle = GameObject.Find("LaneSongTitle");
+            var laneSongSubtitle = GameObject.Find("LaneSongSubtitle");
+            TextMeshProUGUI subtitleText;
+
+            var laneCoverLeft = GameObject.Find("LaneCoverLeft");
+            var laneCoverRight = GameObject.Find("LaneCoverRight");
+
+            Vector2 leftPos;
+            Vector2 rightPos;
+
+            if (isInitialClose)
+            {
+                laneSongTitle = GameObject.Instantiate(songInfoSongTitleObject, canvasBack.transform);
+                laneSongTitle.name = "LaneSongTitle";
+                laneSongTitle.transform.position = new Vector2(250, 140);
+                laneSongSubtitle = GameObject.Instantiate(laneSongTitle, canvasBack.transform);
+                laneSongSubtitle.name = "LaneSongSubtitle";
+                laneSongSubtitle.transform.position = new Vector2(250, 85);
+                subtitleText = laneSongSubtitle.GetComponent<TextMeshProUGUI>();
+                subtitleText.fontSize = 34;
+
+                int leftX = 1211;
+                laneCoverLeft = AssetUtility.CreateImageChild(canvasBack, "LaneCoverLeft", new Vector2(leftX, 596), Path.Combine("Enso", "LaneCover.png"));
+                laneCoverRight = AssetUtility.CreateImageChild(canvasBack, "LaneCoverRight", new Vector2(leftX, 596), Path.Combine("Enso", "LaneCover.png"));
+                laneCoverLeft.transform.localScale = new Vector3(-1, 1, 1);
+            }
+            else
+            {
+                leftPos = new Vector2(laneCoverLeft.transform.localPosition.x, laneCoverLeft.transform.localPosition.y);
+                rightPos = new Vector2(laneCoverRight.transform.localPosition.x, laneCoverRight.transform.localPosition.y);
+
+                Plugin.Instance.StartCoroutine(AssetUtility.MoveOverSeconds(laneCoverLeft, leftPos + new Vector2(711, 0), 0.2f));
+                Plugin.Instance.StartCoroutine(AssetUtility.MoveOverSeconds(laneCoverRight, rightPos - new Vector2(711, 0), 0.2f));
+                DaniSoundManager.PlaySound("lane_close.bin", false);
+            }
+
+            // The initial open will display the song title at the top right a bit sooner than the later songs
+
+            yield return new WaitForSeconds(3);
+
+            DaniDojoAssets.EnsoAssets.AdvanceSongPanel(DaniPlayManager.GetCurrentCourse(), DaniPlayManager.GetCurrentSongNumber());
+
+            Plugin.Instance.StartCoroutine(AssetUtility.ChangeTransparencyOverSeconds(laneSongTitle, 0, true));
+            Plugin.Instance.StartCoroutine(AssetUtility.ChangeTransparencyOverSeconds(laneSongSubtitle, 0, true));
+
+            var wordDataManager = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.WordDataMgr;
+            var songTitle = wordDataManager.GetWordListInfo("song_" + songId).Text;
+            var songSubtitle = wordDataManager.GetWordListInfo("song_sub_" + songId).Text;
+
+            laneSongTitle.GetComponent<TextMeshProUGUI>().text = songTitle;
+            subtitleText = laneSongSubtitle.GetComponent<TextMeshProUGUI>();
+            subtitleText.text = songSubtitle;
+
+            WordDataManager.WordListKeysInfo wordListInfo = wordDataManager.GetWordListInfo("song_sub_" + songId);
+            FontTMPManager fontTMPMgr = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.FontTMPMgr;
+            subtitleText.fontSharedMaterial = fontTMPMgr.GetDefaultFontMaterial(wordListInfo.FontType, DataConst.DefaultFontMaterialType.OutlineBlack);
+
+            leftPos = new Vector2(laneCoverLeft.transform.localPosition.x, laneCoverLeft.transform.localPosition.y);
+            rightPos = new Vector2(laneCoverRight.transform.localPosition.x, laneCoverRight.transform.localPosition.y);
+
+            Plugin.Instance.StartCoroutine(AssetUtility.MoveOverSeconds(laneCoverLeft, leftPos - new Vector2(711, 0), 0.2f));
+            Plugin.Instance.StartCoroutine(AssetUtility.MoveOverSeconds(laneCoverRight, rightPos + new Vector2(711, 0), 0.2f));
+
+            DaniSoundManager.PlaySound("lane_open.bin", false);
+
+
+            yield return new WaitForSeconds(3);
+
+            Plugin.Instance.StartCoroutine(AssetUtility.ChangeTransparencyOverSeconds(laneSongTitle, 2, false));
+            Plugin.Instance.StartCoroutine(AssetUtility.ChangeTransparencyOverSeconds(laneSongSubtitle, 2, false));
+
+            songInfoLayout.txt.text = songTitle;
+            songInfoLayout.txtCenter.text = "";
+            songInfoLayout.Update();
+            songInfoPlayer.m_isSongInfoCenter = songInfoLayout.txtCenter.text != "";
+            songInfoPlayer.m_Genre = genreNo;
+            songInfoPlayer.m_songId = songId;
+            songInfoPlayer.m_SongName = songTitle;
+            songInfoPlayer.m_bExecute = true;
+
+
+            yield return new WaitForSeconds(2);
+
+            PauseEnso(false);
+
+            yield break;
+        }
+
+        public static void AdvanceSong(DaniCourse course, int songIndex)
+        {
+            MusicDataInterface.MusicInfoAccesser musicInfoAccesser = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.MusicData.musicInfoAccessers.Find((MusicDataInterface.MusicInfoAccesser info) => info.Id == course.Songs[songIndex].SongId);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoType = EnsoData.EnsoType.Normal;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.rankMatchType = EnsoData.RankMatchType.None;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.musicuid = musicInfoAccesser.Id;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.musicUniqueId = musicInfoAccesser.UniqueId;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.genre = (EnsoData.SongGenre)musicInfoAccesser.GenreNo;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.playerNum = 1;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].neiroId = 0;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].courseType = course.Songs[songIndex].Level;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].speed = DataConst.SpeedTypes.Normal;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].dron = DataConst.OptionOnOff.Off;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].reverse = DataConst.OptionOnOff.Off;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].randomlv = DataConst.RandomLevel.None;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].special = DataConst.SpecialTypes.None;
+            // To prevent highscores from showing up
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].hiScore = 2000000;
+
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.songFilePath = musicInfoAccesser.SongFileName;
+
+            SystemOption systemOption;
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.PlayData.GetSystemOption(out systemOption, false);
+            int deviceTypeIndex = EnsoDataManager.GetDeviceTypeIndex(TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.ensoPlayerSettings[0].inputDevice);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.noteDispOffset = (int)systemOption.onpuDispLevels[deviceTypeIndex];
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.noteDelay = (int)systemOption.onpuHitLevels[deviceTypeIndex];
+
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.songVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.InGameSong);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.seVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Se);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.voiceVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Voice);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.bgmVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.Bgm);
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings.neiroVolume = TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MySoundManager.GetVolume(SoundManager.SoundType.InGameNeiro);
+
+
+            TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.SetSettings(ref TaikoSingletonMonoBehaviour<CommonObjects>.Instance.MyDataManager.EnsoData.ensoSettings);
+
+
+            var ensoSceneObject = GameObject.Find("SceneEnsoGame");
+
+            var ensoPlayingParameterObj = AssetUtility.GetChildByName(ensoSceneObject, "EnsoPlayingParameter");
+            var ensoGameManagerObj = AssetUtility.GetChildByName(ensoSceneObject, "EnsoGameManager");
+            var fumenLoaderObj = AssetUtility.GetChildByName(ensoSceneObject, "FumenLoader");
+            //var ensoGraphicManagerObj = AssetUtility.GetChildByName(ensoSceneObject, "EnsoGraphicManager");
+            var ensoPlayingParameter = ensoPlayingParameterObj.GetComponent<EnsoPlayingParameter>();
+            var ensoGameManager = ensoGameManagerObj.GetComponent<EnsoGameManager>();
+            var fumenLoader = fumenLoaderObj.GetComponent<FumenLoader>();
+
+
+            //var ensoGraphicManager = fumenLoaderObj.GetComponent<EnsoGraphicManager>();
+
+            CreateAssets = false;
+
+            ensoGameManager.taikoCorePlayer.EnsoFinailize();
+
+            fumenLoader.Awake();
+            ensoGameManager.Awake();
+            ensoPlayingParameter.Awake();
+            fumenLoader.Start();
+            ensoGameManager.Start();
+            ensoPlayingParameter.TotalTime = 0;
+            ensoGameManager.totalTime = 0;
+            ensoGameManager.adjustCounter = 0;
+            ensoGameManager.adjustSubTime = 0.0;
+            ensoGameManager.adjustTime = 0.0;
+            ensoGameManager.ensoSound.neiroPlayer[0].Load();
+
+            Plugin.Instance.StartCoroutine(CloseLaneCovers(false, course.Songs[songIndex].SongId, (EnsoData.SongGenre)musicInfoAccesser.GenreNo));
+
+        }
+
+        public static bool EnsoPause = false;
+
+        static void PauseEnso(bool pause)
+        {
+            EnsoPause = pause;
+
+            Plugin.Instance.StartCoroutine(PauseEnsoSong(pause));
+
+            Plugin.LogInfo("EnsoPause: " + EnsoPause);
+
+        }
+
+        static IEnumerator PauseEnsoSong(bool pause)
+        {
+            GameObject ensoSceneObject;
+            do
+            {
+                ensoSceneObject = GameObject.Find("SceneEnsoGame");
+                yield return null;
+            } while (ensoSceneObject == null);
+
+            var ensoPlayingParameterObj = AssetUtility.GetChildByName(ensoSceneObject, "EnsoPlayingParameter");
+            var ensoGameManagerObj = AssetUtility.GetChildByName(ensoSceneObject, "EnsoGameManager");
+
+            var ensoPlayingParameter = ensoPlayingParameterObj.GetComponent<EnsoPlayingParameter>();
+            var ensoGameManager = ensoGameManagerObj.GetComponent<EnsoGameManager>();
+
+
+            ensoPlayingParameter.TotalTime = 0;
+            ensoGameManager.totalTime = 0;
+
+            if (pause)
+            {
+                Plugin.LogInfo("StopSong");
+                ensoGameManager.ensoSound.StopSong();
+                var laneHitEffects = GameObject.FindObjectOfType<LaneHitEffects>();
+                laneHitEffects.Start();
+                laneHitEffects.isStart = false;
+                laneHitEffects.branchEffect.AnimClipsAPI_PlayClip(0);
+            }
+            if (!pause)
+            {
+                Plugin.LogInfo("PrepareSong");
+                ensoGameManager.ensoSound.StopSong();
+                ensoGameManager.ensoSound.PrepareSong(0);
+                ensoGameManager.ensoSound.PlaySong();
             }
         }
 
 
-        [HarmonyPatch(typeof(EnsoGameManager))]
-        [HarmonyPatch(nameof(EnsoGameManager.ProcExecMain))]
+
+
+
+        [HarmonyPatch(typeof(EnsoGraphicManager))]
+        [HarmonyPatch(nameof(EnsoGraphicManager.CreateParts))]
         [HarmonyPatch(MethodType.Normal)]
-        [HarmonyPostfix]
-        public static void EnsoGameManager_ProcExecMain_Postfix_GetNoteResults(EnsoGameManager __instance)
+        [HarmonyPrefix]
+        public static bool EnsoGraphicManager_CreateParts_Prefix(EnsoGraphicManager __instance)
         {
-            if (DaniPlayManager.CheckIsInDan())
-            {
-                var frameResult = __instance.ensoParam.GetFrameResults();
-                for (int i = 0; i < frameResult.hitResultInfoNum - 1; i++)
-                {
-                    if (frameResult.hitResultInfo[i].player == 0)
-                    {
-                        var info = frameResult.hitResultInfo[i];
-
-                        DaniPlayManager.AddHitResult(info);
-                        int hitResult = info.hitResult;
-                        if (info.onpuType == (int)OnpuTypes.Don || info.onpuType == (int)OnpuTypes.Do || info.onpuType == (int)OnpuTypes.Ko || info.onpuType == (int)OnpuTypes.Katsu || info.onpuType == (int)OnpuTypes.Ka
-                            || info.onpuType == (int)OnpuTypes.DaiDon || info.onpuType == (int)OnpuTypes.DaiKatsu
-                            || info.onpuType == (int)OnpuTypes.WDon || info.onpuType == (int)OnpuTypes.WKatsu)
-                        {
-                            if (hitResult == (int)HitResultTypes.Fuka || hitResult == (int)HitResultTypes.Drop)
-                            {
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Bads);
-                            }
-                            else if (hitResult == (int)HitResultTypes.Ka)
-                            {
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Oks);
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.TotalHits);
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Combo);
-                            }
-                            else if (hitResult == (int)HitResultTypes.Ryo)
-                            {
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Goods);
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.TotalHits);
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Combo);
-                            }
-                        }
-                        else if (info.onpuType == (int)OnpuTypes.Renda || info.onpuType == (int)OnpuTypes.DaiRenda)
-                        {
-                            if (hitResult == (int)HitResultTypes.Ryo)
-                            {
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.TotalHits);
-                                DaniDojoAssets.EnsoAssets.UpdateRequirementBar(Data.BorderType.Drumroll);
-                            }
-                        }
-                    }
-                }
-            }
+            return CreateAssets;
         }
-
-        #endregion
-
 
         static string baseImageFilePath = Plugin.Instance.ConfigDaniDojoAssetLocation.Value;
 
@@ -227,7 +410,7 @@ namespace DaniDojo.Patches
         [HarmonyPostfix]
         public static void EnsoGraphicManager_CreateParts_Postfix(EnsoGraphicManager __instance)
         {
-            if (DaniPlayManager.CheckIsInDan())
+            if (DaniPlayManager.CheckIsInDan() && CreateAssets)
             {
                 Plugin.Log.LogInfo("Image Change Start");
 
@@ -396,52 +579,54 @@ namespace DaniDojo.Patches
 
                 Plugin.Log.LogInfo("Panels created");
 
-                var currentCourse = DaniPlayManager.GetCurrentCourse();
-                if (currentCourse != null)
-                {
-                    var courseId = currentCourse.Id;
-                    if (int.TryParse(courseId, out int _))
-                    {
-                        courseId = currentCourse.Title;
-                    }
+                CommonAssets.CreateDaniCourse(DaniDojoParent, new Vector2(1548, 5), DaniPlayManager.GetCurrentCourse());
 
-                    (string bgImage, string textImage) imageNames;
+                //var currentCourse = DaniPlayManager.GetCurrentCourse();
+                //if (currentCourse != null)
+                //{
+                //    var courseId = currentCourse.Id;
+                //    if (int.TryParse(courseId, out int _))
+                //    {
+                //        courseId = currentCourse.Title;
+                //    }
 
-                    imageNames = courseId switch
-                    {
-                        "5kyuu" or "五級 5th Kyu" => ("WoodBg.png", "kyuu5.png"),
-                        "4kyuu" or "四級 4th Kyu" => ("WoodBg.png", "kyuu4.png"),
-                        "3kyuu" or "三級 3rd Kyu" => ("WoodBg.png", "kyuu3.png"),
-                        "2kyuu" or "二級 2nd Kyu" => ("WoodBg.png", "kyuu2.png"),
-                        "1kyuu" or "一級 1st Kyu" => ("WoodBg.png", "kyuu1.png"),
-                        "1dan" or "初段 1st Dan" => ("BlueBg.png", "dan1.png"),
-                        "2dan" or "二段 2nd Dan" => ("BlueBg.png", "dan2.png"),
-                        "3dan" or "三段 3rd Dan" => ("BlueBg.png", "dan3.png"),
-                        "4dan" or "四段 4th Dan" => ("BlueBg.png", "dan4.png"),
-                        "5dan" or "五段 5th Dan" => ("BlueBg.png", "dan5.png"),
-                        "6dan" or "六段 6th Dan" => ("RedBg.png", "dan6.png"),
-                        "7dan" or "七段 7th Dan" => ("RedBg.png", "dan7.png"),
-                        "8dan" or "八段 8th Dan" => ("RedBg.png", "dan8.png"),
-                        "9dan" or "九段 9th Dan" => ("RedBg.png", "dan9.png"),
-                        "10dan" or "十段 10th Dan" => ("RedBg.png", "dan10.png"),
-                        "11dan" or "玄人 Kuroto" => ("SilverBg.png", "kuroto.png"),
-                        "12dan" or "名人 Meijin" => ("SilverBg.png", "meijin.png"),
-                        "13dan" or "超人 Chojin" => ("SilverBg.png", "chojin.png"),
-                        "14dan" or "達人 Tatsujin" => ("GoldBg.png", "tatsujin.png"),
-                        _ => ("TanBg.png", "gaiden.png"),
-                    };
+                //    (string bgImage, string textImage) imageNames;
 
-                    string bgImageName = imageNames.bgImage;
-                    string textImageName = imageNames.textImage;
+                //    imageNames = courseId switch
+                //    {
+                //        "5kyuu" or "五級 5th Kyu" => ("WoodBg.png", "kyuu5.png"),
+                //        "4kyuu" or "四級 4th Kyu" => ("WoodBg.png", "kyuu4.png"),
+                //        "3kyuu" or "三級 3rd Kyu" => ("WoodBg.png", "kyuu3.png"),
+                //        "2kyuu" or "二級 2nd Kyu" => ("WoodBg.png", "kyuu2.png"),
+                //        "1kyuu" or "一級 1st Kyu" => ("WoodBg.png", "kyuu1.png"),
+                //        "1dan" or "初段 1st Dan" => ("BlueBg.png", "dan1.png"),
+                //        "2dan" or "二段 2nd Dan" => ("BlueBg.png", "dan2.png"),
+                //        "3dan" or "三段 3rd Dan" => ("BlueBg.png", "dan3.png"),
+                //        "4dan" or "四段 4th Dan" => ("BlueBg.png", "dan4.png"),
+                //        "5dan" or "五段 5th Dan" => ("BlueBg.png", "dan5.png"),
+                //        "6dan" or "六段 6th Dan" => ("RedBg.png", "dan6.png"),
+                //        "7dan" or "七段 7th Dan" => ("RedBg.png", "dan7.png"),
+                //        "8dan" or "八段 8th Dan" => ("RedBg.png", "dan8.png"),
+                //        "9dan" or "九段 9th Dan" => ("RedBg.png", "dan9.png"),
+                //        "10dan" or "十段 10th Dan" => ("RedBg.png", "dan10.png"),
+                //        "11dan" or "玄人 Kuroto" => ("SilverBg.png", "kuroto.png"),
+                //        "12dan" or "名人 Meijin" => ("SilverBg.png", "meijin.png"),
+                //        "13dan" or "超人 Chojin" => ("SilverBg.png", "chojin.png"),
+                //        "14dan" or "達人 Tatsujin" => ("GoldBg.png", "tatsujin.png"),
+                //        _ => ("TanBg.png", "gaiden.png"),
+                //    };
 
-                    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerBack", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", bgImageName), new Vector2(1548, 5), DaniDojoParent.transform);
-                    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerText", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", textImageName), new Vector2(1600, 129), DaniDojoParent.transform);
-                }
-                else
-                {
-                    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerBack", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", "RedBg.png"), new Vector2(1548, 5), DaniDojoParent.transform);
-                    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerText", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", "10dan.png"), new Vector2(1600, 129), DaniDojoParent.transform);
-                }
+                //    string bgImageName = imageNames.bgImage;
+                //    string textImageName = imageNames.textImage;
+
+                //    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerBack", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", bgImageName), new Vector2(1548, 5), DaniDojoParent.transform);
+                //    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerText", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", textImageName), new Vector2(1600, 129), DaniDojoParent.transform);
+                //}
+                //else
+                //{
+                //    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerBack", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", "RedBg.png"), new Vector2(1548, 5), DaniDojoParent.transform);
+                //    DaniDojoAssetUtility.CreateImage("CurrentDanMarkerText", Path.Combine(baseImageFilePath, "Course", "DaniCourseIcons", "10dan.png"), new Vector2(1600, 129), DaniDojoParent.transform);
+                //}
 
                 Plugin.Log.LogInfo("CurrentDanMarker created");
 
@@ -488,14 +673,14 @@ namespace DaniDojo.Patches
         {
             if (DaniPlayManager.CheckIsInDan())
             {
-                cmbNum = (uint)DaniPlayManager.GetCurrentCombo(); 
+                cmbNum = (uint)DaniPlayManager.GetCurrentCombo();
             }
             return true;
         }
 
 
 
-        
+
 
 
 
@@ -538,9 +723,7 @@ namespace DaniDojo.Patches
             {
                 DaniPlayManager.RestartDanPlay();
 
-                var songData = DaniPlayManager.GetSongData();
-
-                BeginSong(songData.SongId, songData.Level);
+                BeginDan(DaniPlayManager.GetCurrentCourse());
             }
         }
 

--- a/DaniDojo/OldPatches/testing.cs
+++ b/DaniDojo/OldPatches/testing.cs
@@ -1,22 +1,22 @@
-﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿//using HarmonyLib;
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Text;
+//using System.Threading.Tasks;
 
-namespace DaniDojo.Patches
-{
-    internal class testing
-    {
-        [HarmonyPatch(typeof(PlayerName))]
-        [HarmonyPatch(nameof(PlayerName.Start))]
-        [HarmonyPatch(MethodType.Normal)]
-        [HarmonyPrefix]
-        public static bool PlayerName_Start_Prefix(PlayerName __instance)
-        {
-            //Plugin.Log.LogInfo("PlayerName Start");
-            return true;
-        }
-    }
-}
+//namespace DaniDojo.Patches
+//{
+//    internal class testing
+//    {
+//        [HarmonyPatch(typeof(PlayerName))]
+//        [HarmonyPatch(nameof(PlayerName.Start))]
+//        [HarmonyPatch(MethodType.Normal)]
+//        [HarmonyPrefix]
+//        public static bool PlayerName_Start_Prefix(PlayerName __instance)
+//        {
+//            //Plugin.Log.LogInfo("PlayerName Start");
+//            return true;
+//        }
+//    }
+//}

--- a/DaniDojo/Plugin.cs
+++ b/DaniDojo/Plugin.cs
@@ -32,18 +32,18 @@ namespace DaniDojo
         private Harmony _harmony;
         public static ManualLogSource Log;
 
-        public  ConfigEntry<bool> ConfigEnabled;
-        public  ConfigEntry<string> ConfigDaniDojoDataLocation;
-        public  ConfigEntry<string> ConfigDaniDojoAssetLocation;
-        public  ConfigEntry<string> ConfigDaniDojoSaveLocation;
+        public ConfigEntry<bool> ConfigEnabled;
+        public ConfigEntry<string> ConfigDaniDojoDataLocation;
+        public ConfigEntry<string> ConfigDaniDojoAssetLocation;
+        public ConfigEntry<string> ConfigDaniDojoSaveLocation;
 
 
         public ConfigEntry<string> ConfigSongTitleLanguage;
 
-        public  ConfigEntry<bool> ConfigNamePlateDanRankEnabled;
-               
-        public  ConfigEntry<bool> ConfigLoggingEnabled;
-        public  ConfigEntry<int> ConfigLoggingDetailLevelEnabled;
+        public ConfigEntry<bool> ConfigNamePlateDanRankEnabled;
+
+        public ConfigEntry<bool> ConfigLoggingEnabled;
+        public ConfigEntry<int> ConfigLoggingDetailLevelEnabled;
 
 
         //public static List<DaniSeriesData> AllDaniData;
@@ -88,7 +88,7 @@ namespace DaniDojo
 
             ConfigDaniDojoDataLocation = Config.Bind("Data",
                 "DaniDojoDataLocation",
-                "BepInEx\\data\\DaniDojo",
+                "BepInEx\\data\\DaniDojoCourses",
                 "The file location for all dani dojo course data.");
 
             ConfigDaniDojoAssetLocation = Config.Bind("Data",
@@ -113,7 +113,7 @@ namespace DaniDojo
 
             ConfigLoggingEnabled = Config.Bind("Debug",
                 "LoggingEnabled",
-                false,
+                true,
                 "Enables logs to be sent to the console.");
 
             ConfigLoggingDetailLevelEnabled = Config.Bind("Debug",
@@ -136,168 +136,6 @@ namespace DaniDojo
             Assets = AssetBundle.LoadFromFile(assetBundlePath);
             Plugin.Log.LogInfo("danidojo scene loaded?");
         }
-
-        //private void InitializeDaniData()
-        //{
-        //    AllDaniData = new List<DaniSeriesData>();
-        //    string folderPath = Plugin.Instance.ConfigDaniDojoDataLocation.Value;
-        //    if (!Directory.Exists(folderPath))
-        //    {
-        //        Directory.CreateDirectory(folderPath);
-        //    }
-        //    DirectoryInfo dirInfo = new DirectoryInfo(folderPath);
-        //    var files = dirInfo.GetFiles("*.json", SearchOption.AllDirectories).ToList();
-        //    for (int i = 0; i < files.Count; i++)
-        //    {
-        //        Log.LogInfo("Initializing " + files[i].Name);
-        //        var text = File.ReadAllText(files[i].FullName);
-        //        JsonNode node = JsonNode.Parse(text)!;
-        //        DaniSeriesData seriesData = new DaniSeriesData();
-        //        seriesData.seriesTitle = node["danSeriesTitle"]!.GetValue<string>();
-        //        seriesData.seriesId = node["danSeriesId"]!.GetValue<string>();
-        //        seriesData.isActiveDan = node["isActiveDan"]!.GetValue<bool>();
-        //        seriesData.order = node["order"]!.GetValue<int>();
-        //        var courses = node["courses"].AsArray();
-        //        for (int j = 0; j < courses.Count; j++)
-        //        {
-        //            DaniData course = new DaniData(courses[j]!, seriesData);
-
-        //            seriesData.courseData.Add(course);
-        //        }
-        //        seriesData.courseData.Sort((x, y) => x.danId > y.danId ? 1 : -1);
-
-        //        AllDaniData.Add(seriesData);
-        //    }
-        //    // This needs to be more robust
-        //    // Case where x.order == y.order would probably break
-        //    AllDaniData.Sort((x, y) => x.order > y.order ? 1 : -1);
-        //    Log.LogInfo("AllDaniData Initialized!");
-        //}
-
-        //private void InitializeDaniRecords()
-        //{
-        //    Plugin.Log.LogInfo("InitializeDaniRecords");
-        //    AllDaniScores = new List<DaniDojoCurrentPlay>();
-        //    string folderPath = ConfigDaniDojoSaveLocation.Value;
-        //    if (!Directory.Exists(folderPath))
-        //    {
-        //        Directory.CreateDirectory(folderPath);
-        //    }
-        //    Plugin.Log.LogInfo("1");
-        //    DirectoryInfo dirInfo = new DirectoryInfo(folderPath);
-        //    var files = dirInfo.GetFiles("dansave.json").ToList();
-        //    Plugin.Log.LogInfo("2");
-        //    if (files.Count != 0)
-        //    {
-        //        var text = File.ReadAllText(files[0].FullName);
-        //        JsonNode node = JsonNode.Parse(text)!;
-        //        Plugin.Log.LogInfo("3");
-
-        //        //List<uint> allHashes = new List<uint>();
-        //        var courses = node["courses"].AsArray();
-        //        Plugin.Log.LogInfo("4");
-        //        for (int i = 0; i < courses.Count; i++)
-        //        {
-        //            //allHashes.Add(courses[i]!["danHash"].GetValue<uint>());
-        //            Plugin.Log.LogInfo("courses[i]!.GetValue<uint>(): " + courses[i]!["danHash"].GetValue<uint>());
-        //            DaniDojoCurrentPlay record = new DaniDojoCurrentPlay(courses[i]);
-
-        //            Log.LogInfo("1");
-                    
-        //            AllDaniScores.Add(record);
-        //        }
-        //        Plugin.Log.LogInfo("5");
-
-
-
-        //        for (int i = 0; i < CourseDataManager.AllSeriesData.Count; i++)
-        //        {
-        //            for (int j = 0; j < CourseDataManager.AllSeriesData[i].Courses.Count; j++)
-        //            {
-        //                var course = CourseDataManager.AllSeriesData[i].Courses[j];
-        //                for (int k = 0; k < AllDaniScores.Count; k++)
-        //                {
-        //                    if (course.Hash == AllDaniScores[k].hash)
-        //                    {
-        //                        Log.LogInfo("Started reading in dan hash: " + AllDaniScores[k].hash);
-        //                        AllDaniScores[k].course = course;
-        //                        AllDaniScores[k].danResult = AllDaniScores[k].CalculateRequirements();
-        //                        AllDaniScores[k].comboResult = AllDaniScores[k].CalculateComboResult();
-
-        //                        break;
-        //                    }
-        //                }
-        //            }
-        //        }
-        //        Plugin.Log.LogInfo("6");
-
-        //    }
-        //    Plugin.Log.LogInfo("InitializeDaniRecords Finished!");
-        //}
-
-        //public void SaveDaniRecords()
-        //{
-        //    Plugin.Log.LogInfo("SaveDaniRecords Start");
-        //    var scoresJsonObject = new JsonObject()
-        //    {
-        //        ["courses"] = new JsonArray(),
-        //    };
-
-        //    for (int i = 0; i < AllDaniScores.Count; i++)
-        //    {
-        //        Plugin.Log.LogInfo("Starting course " + (i + 1));
-        //        var course = new JsonObject
-        //        {
-        //            ["danHash"] = AllDaniScores[i].hash,
-        //            ["danResult"] = (int)AllDaniScores[i].danResult,
-        //            ["danComboResult"] = (int)AllDaniScores[i].comboResult,
-        //            ["playCount"] = AllDaniScores[i].playCount,
-        //            ["songReached"] = AllDaniScores[i].songReached,
-        //            ["totalSoulGauge"] = 100,
-        //            ["totalCombo"] = AllDaniScores[i].combo,
-        //            ["songScores"] = new JsonArray(),
-        //        };
-
-        //        for (int j = 0; j < AllDaniScores[i].songResults.Count; j++)
-        //        {
-        //            var song = AllDaniScores[i].songResults[j];
-        //            var json = new JsonObject()
-        //            {
-        //                ["score"] = song.score,
-        //                ["goods"] = song.goods,
-        //                ["oks"] = song.oks,
-        //                ["bads"] = song.bads,
-        //                ["combo"] = song.songCombo,
-        //                ["drumroll"] = song.renda,
-        //                ["totalhits"] = song.goods + song.oks + song.renda,
-        //            };
-        //            course["songScores"].AsArray().Add(json);
-        //        }
-        //        scoresJsonObject["courses"].AsArray().Add(course);
-        //        Plugin.Log.LogInfo("Added course " + (i + 1));
-        //    }
-        //    Plugin.Log.LogInfo("SaveDaniRecords 10");
-
-        //    var filePath = Path.Combine(ConfigDaniDojoSaveLocation.Value, "dansave.json");
-        //    Plugin.Log.LogInfo("FilePath: " + filePath);
-
-        //    try
-        //    {
-        //        JsonSerializerOptions options = new JsonSerializerOptions();
-        //        options.WriteIndented = true;
-        //        var jsonString = scoresJsonObject.ToJsonString(options);
-        //        //Plugin.Log.LogInfo("JsonString:" + jsonString);
-        //        File.WriteAllText(filePath, jsonString);
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Log.LogInfo("Error creating JsonString: " + e.Message);
-        //        throw;
-        //    }
-
-
-        //    Plugin.Log.LogInfo("SaveDaniRecords Finished");
-        //}
 
         private void SetupHarmony()
         {
@@ -329,6 +167,8 @@ namespace DaniDojo
                 _harmony.PatchAll(typeof(EnsoPauseHook));
 
                 _harmony.PatchAll(typeof(ResultsHook));
+                _harmony.PatchAll(typeof(HitResultHook));
+                _harmony.PatchAll(typeof(LoadingScreenHook));
 
 
 


### PR DESCRIPTION
Full changelog:
- Added proper support for Gaiden and Sousaku courses. 
- There's no loading screen between songs anymore.
- Added the lane cover for song transitions, including audio and displaying the song title and subtitle. 
- Fully moved over the asset creation to the new version, eliminating some bugs with loading assets even though they exist. 
- Bads and Oks now properly have rainbows in the results screen. 
- Added support for 6th-10th Kyu assets.
- Added a loading screen for starting dans.
- Removed the Input Guide in the course select.
- Changed the default config for DaniDojo Courses folder location to "DaniDojoCourses" 
- Changed the default config to enable Logging by default. 
- Reworked how goods/oks/bads/drumroll are detected. It's now more accurate, but might be more resource intensive. Up for change in the future. 
- Added support for English and Japanese titles for Gaiden/Sousaku courses. 
- Score now properly transfers between songs. It will reset if it goes past 10,000,000, but that is not fixable (without a lot of extra work, not worth it)