### PR TITLE
Minor bug fix

### DIFF
--- a/DaniDojo/Assets/AssetUtility.cs
+++ b/DaniDojo/Assets/AssetUtility.cs
@@ -34,6 +34,14 @@ namespace DaniDojo.Assets
                 {
                     AssetFilePath = files[0].Directory.FullName;
                 }
+                else
+                {
+                    files = dirInfo.GetFiles("CustomGameModes.scene");
+                    if (files.Length != 0)
+                    {
+                        AssetFilePath = files[0].Directory.FullName;
+                    }
+                }
             }
 
             // If the file doesn't start with the Asset path, append it on

--- a/DaniDojo/DaniDojo.csproj
+++ b/DaniDojo/DaniDojo.csproj
@@ -32,12 +32,12 @@
     <TargetFramework Condition="$(DefineConstants.Contains('TAIKO_MONO'))">net48</TargetFramework>
     <AssemblyName>com.db.DaniDojo</AssemblyName>
     <Description>A mod to allow players to play DaniDojo mode in TDMX.</Description>
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>DaniDojo</RootNamespace>
     <PackageId>DaniDojo</PackageId>
-    <PackageVersion>0.5.3</PackageVersion>
+    <PackageVersion>0.5.4</PackageVersion>
     <Configurations>Release-IL2CPP;Release-Mono;Debug-IL2CPP;Debug-Mono</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>

--- a/DaniDojo/Managers/SaveDataManager.cs
+++ b/DaniDojo/Managers/SaveDataManager.cs
@@ -385,7 +385,7 @@ namespace DaniDojo.Managers
         {
             var series = CourseDataManager.GetActiveSeries();
             SaveCourse highestCourseRecord = null;
-            for (int i = 0; i < series.Courses.Count - 1; i++)
+            for (int i = 0; i < series.Courses.Count; i++)
             {
                 var saveCourse = GetCourseRecord(series.Courses[i].Hash);
                 if (saveCourse.RankCombo.Rank >= DaniRank.RedClear)


### PR DESCRIPTION
Added a check for Asset file locations by searching for CustomGameMods.scene, which is a requirement. 
Fixed a bug where the final dan course in a series would not display on the nameplate when cleared. Possibly fixes (and hopefully not causes) a bug in other areas as well that I didn't look for.